### PR TITLE
Fix AirCube ZHA quirk import on current zigpy

### DIFF
--- a/zha/aircube.py
+++ b/zha/aircube.py
@@ -29,6 +29,7 @@ class AirQualityCluster(CustomCluster):
         AirQualityCluster.cluster_id,
         endpoint_id=10,
         unit="ppm",
+        device_class=SensorDeviceClass.CO2,
         state_class=SensorStateClass.MEASUREMENT,
         fallback_name="eCO2",
     )


### PR DESCRIPTION
## Summary
Fix the AirCube ZHA quirk for newer zigpy/Home Assistant versions by adding a missing `device_class` to the eCO2 sensor metadata.

## Problem
On current Home Assistant / zigpy, the custom quirk can fail to import with:

```text
ValueError: EntityMetadata must have a translation_key or device_class
```

This prevents the custom AirCube entities from loading in ZHA.

## Change
Add `device_class=SensorDeviceClass.CO2` to the `eco2` sensor definition in `zha/aircube.py`.

## Verification
Verified against Home Assistant logs:
- before: custom quirk import failed
- after: quirk loads and matches as `zigpy.quirks.v2.CustomDeviceV2`
- ZHA now exposes the expected AirCube sensors, including carbon dioxide, VOC, and AQI
