### PR TITLE
Feature brightness control

### DIFF
--- a/firmware/main/zigbee.c
+++ b/firmware/main/zigbee.c
@@ -10,12 +10,14 @@
  *   - Identify (0x0003)          : Standard identify
  *   - Temperature Meas (0x0402)  : Actual temperature in 0.01 C
  *   - Humidity Meas (0x0405)     : Actual humidity in 0.01 %
- *   - Custom (0xFC01)            : eCO2, eTVOC, AQI (for Z2M)
+ *   - Custom (0xFC01)            : eCO2, eTVOC, AQI
+ *   - Analog Output (0x000D)     : LED brightness (0-100)
  *
  * @author StuckAtPrototype, LLC
  */
 
 #include "zigbee.h"
+#include "led.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -35,9 +37,12 @@ static const char *TAG = "zigbee";
 
 /* Custom cluster for air quality metrics (manufacturer-specific range) */
 #define CUSTOM_CLUSTER_ID           0xFC01
-#define ATTR_ECO2_ID                0x0000   /* uint16 – ppm  */
-#define ATTR_ETVOC_ID               0x0001   /* uint16 – ppb  */
+#define ATTR_ECO2_ID                0x0000   /* uint16 – ppm   */
+#define ATTR_ETVOC_ID               0x0001   /* uint16 – ppb   */
 #define ATTR_AQI_ID                 0x0002   /* uint16 – index */
+
+/* Analog Output cluster (0x000D) for brightness – standard cluster so
+   ZCL Write Attributes from coordinators is handled natively by ZBOSS. */
 
 /* Zigbee channel mask – scan all channels */
 #define AIRCUBE_CHANNEL_MASK        ESP_ZB_TRANSCEIVER_ALL_CHANNELS_MASK
@@ -68,14 +73,14 @@ static uint16_t humidity_to_zb(float rh)
     return (uint16_t)(rh * 100.0f);
 }
 
-static void report_custom_attr(uint16_t attr_id)
+static void report_attr(uint16_t cluster_id, uint16_t attr_id)
 {
     esp_zb_zcl_report_attr_cmd_t report_cmd = { 0 };
-    report_cmd.zcl_basic_cmd.dst_addr_u.addr_short = 0x0000; /* Coordinator */
+    report_cmd.zcl_basic_cmd.dst_addr_u.addr_short = 0x0000;
     report_cmd.zcl_basic_cmd.dst_endpoint = 1;
     report_cmd.zcl_basic_cmd.src_endpoint = AIRCUBE_ENDPOINT;
     report_cmd.address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT;
-    report_cmd.clusterID = CUSTOM_CLUSTER_ID;
+    report_cmd.clusterID = cluster_id;
     report_cmd.manuf_specific = 0;
     report_cmd.direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI;
     report_cmd.dis_default_resp = 1;
@@ -281,6 +286,17 @@ static esp_zb_cluster_list_t *create_cluster_list(void)
     ESP_ERROR_CHECK(esp_zb_cluster_list_add_custom_cluster(cluster_list,
         custom_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE));
 
+    /* ---- Analog Output cluster 0x000D (brightness, writable) ---- */
+    esp_zb_analog_output_cluster_cfg_t ao_cfg = {
+        .out_of_service = false,
+        .present_value  = 60.0f,
+        .status_flags   = 0,
+    };
+    esp_zb_attribute_list_t *ao_cluster =
+        esp_zb_analog_output_cluster_create(&ao_cfg);
+    ESP_ERROR_CHECK(esp_zb_cluster_list_add_analog_output_cluster(cluster_list,
+        ao_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE));
+
     return cluster_list;
 }
 
@@ -372,6 +388,7 @@ static void configure_reporting(void)
         .manuf_code         = ESP_ZB_ZCL_ATTR_NON_MANUFACTURER_SPECIFIC,
     };
     esp_zb_zcl_update_reporting_info(&aqi_rpt);
+
 }
 
 static void apply_zigbee_tx_power(void)
@@ -395,6 +412,29 @@ static void apply_zigbee_tx_power(void)
     ESP_LOGW(TAG, "Zigbee TX power config is not supported by this ESP Zigbee SDK");
 #endif
 #endif
+}
+
+/* ── Action handler (brightness writes via Analog Output cluster) ─────── */
+
+static esp_err_t zb_action_handler(esp_zb_core_action_callback_id_t callback_id,
+                                   const void *message)
+{
+    if (callback_id == ESP_ZB_CORE_SET_ATTR_VALUE_CB_ID && message) {
+        const esp_zb_zcl_set_attr_value_message_t *m =
+            (const esp_zb_zcl_set_attr_value_message_t *)message;
+
+        if (m->info.dst_endpoint == AIRCUBE_ENDPOINT &&
+            m->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_ANALOG_OUTPUT &&
+            m->attribute.id == ESP_ZB_ZCL_ATTR_ANALOG_OUTPUT_PRESENT_VALUE_ID)
+        {
+            float raw = *(float *)m->attribute.data.value;
+            if (raw < 0.0f)   raw = 0.0f;
+            if (raw > 100.0f) raw = 100.0f;
+            led_set_intensity(raw / 100.0f);
+            ESP_LOGI(TAG, "Brightness set to %.0f%% via Zigbee", raw);
+        }
+    }
+    return ESP_OK;
 }
 
 /* ── Zigbee main task ────────────────────────────────────────────────── */
@@ -426,6 +466,9 @@ static void esp_zb_task(void *pvParameters)
 
     /* Apply configured Zigbee TX power before stack start */
     apply_zigbee_tx_power();
+
+    /* Handle attribute writes from coordinator (brightness via Analog Output) */
+    esp_zb_core_action_handler_register(zb_action_handler);
 
     /* Start the Zigbee stack (false = not coordinator) */
     ESP_ERROR_CHECK(esp_zb_start(false));
@@ -490,10 +533,20 @@ void zigbee_update_sensors(float temp_c, float humidity, int eco2, int etvoc, in
         CUSTOM_CLUSTER_ID, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE,
         ATTR_AQI_ID, &zb_aqi, false);
 
-    /* One-shot attribute reports to ensure ZHA updates */
-    report_custom_attr(ATTR_ECO2_ID);
-    report_custom_attr(ATTR_ETVOC_ID);
-    report_custom_attr(ATTR_AQI_ID);
+    /* Sync current brightness to Analog Output cluster (covers button changes) */
+    float zb_brightness = led_get_intensity() * 100.0f;
+    esp_zb_zcl_set_attribute_val(AIRCUBE_ENDPOINT,
+        ESP_ZB_ZCL_CLUSTER_ID_ANALOG_OUTPUT, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE,
+        ESP_ZB_ZCL_ATTR_ANALOG_OUTPUT_PRESENT_VALUE_ID, &zb_brightness, false);
+
+    /* One-shot attribute reports to ensure coordinator updates */
+    report_attr(ESP_ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT,
+                ESP_ZB_ZCL_ATTR_TEMP_MEASUREMENT_VALUE_ID);
+    report_attr(ESP_ZB_ZCL_CLUSTER_ID_REL_HUMIDITY_MEASUREMENT,
+                ESP_ZB_ZCL_ATTR_REL_HUMIDITY_MEASUREMENT_VALUE_ID);
+    report_attr(CUSTOM_CLUSTER_ID, ATTR_ECO2_ID);
+    report_attr(CUSTOM_CLUSTER_ID, ATTR_ETVOC_ID);
+    report_attr(CUSTOM_CLUSTER_ID, ATTR_AQI_ID);
 
     esp_zb_lock_release();
 }

--- a/firmware/main/zigbee.h
+++ b/firmware/main/zigbee.h
@@ -3,8 +3,9 @@
  * @brief Zigbee integration for AirCube
  *
  * Exposes temperature, humidity, eCO2, eTVOC, and AQI over Zigbee
- * using standard ZCL clusters (temp/humidity) and a manufacturer-specific
- * custom cluster (0xFC01) for air quality metrics.
+ * using standard ZCL clusters (temp/humidity), a manufacturer-specific
+ * custom cluster (0xFC01) for air quality metrics, and the standard
+ * Analog Output cluster (0x000D) for LED brightness control.
  *
  * @author StuckAtPrototype, LLC
  */
@@ -26,6 +27,7 @@ extern "C" {
  *   - Temperature Measurement cluster (0x0402)
  *   - Relative Humidity cluster (0x0405)
  *   - Custom cluster (0xFC01) for eCO2, eTVOC, AQI
+ *   - Analog Output cluster (0x000D) for LED brightness
  *
  * On first boot (factory-new), the stack stays idle until the user
  * triggers pairing via a long button press.  On subsequent boots the

--- a/z2m/aircube.js
+++ b/z2m/aircube.js
@@ -11,10 +11,13 @@
  *   - Temperature Measurement (0x0402)
  *   - Relative Humidity (0x0405)
  *
- * Custom cluster 0xFC01 attributes:
- *   0x0000 = eCO2  (uint16, ppm)
- *   0x0001 = eTVOC (uint16, ppb)
- *   0x0002 = AQI   (uint16, index)
+ * Custom cluster 0xFC01 attributes (read-only sensors):
+ *   0x0000 = eCO2       (uint16, ppm)
+ *   0x0001 = eTVOC      (uint16, ppb)
+ *   0x0002 = AQI        (uint16, index)
+ *
+ * Analog Output cluster 0x000D (writable):
+ *   0x0055 = presentValue (float, 0-100 brightness)
  */
 
 const {temperature, humidity} = require('zigbee-herdsman-converters/lib/modernExtend');
@@ -26,6 +29,9 @@ const CUSTOM_CLUSTER_ID = 0xFC01;
 const ATTR_ECO2  = 0x0000;
 const ATTR_ETVOC = 0x0001;
 const ATTR_AQI   = 0x0002;
+
+const ANALOG_OUTPUT_CLUSTER = 'genAnalogOutput';
+const ATTR_PRESENT_VALUE = 0x0055;
 
 const fzAirCubeAirQuality = {
     cluster: CUSTOM_CLUSTER_ID,
@@ -45,6 +51,27 @@ const fzAirCubeAirQuality = {
     },
 };
 
+const fzAirCubeBrightness = {
+    cluster: ANALOG_OUTPUT_CLUSTER,
+    type: ['attributeReport', 'readResponse'],
+    convert: (model, msg, publish, options, meta) => {
+        if (msg.data.hasOwnProperty('presentValue')) {
+            return {brightness: Math.round(msg.data.presentValue)};
+        }
+    },
+};
+
+const tzAirCubeBrightness = {
+    key: ['brightness'],
+    convertSet: async (entity, key, value, meta) => {
+        await entity.write(ANALOG_OUTPUT_CLUSTER, {presentValue: value});
+        return {state: {brightness: value}};
+    },
+    convertGet: async (entity, key, meta) => {
+        await entity.read(ANALOG_OUTPUT_CLUSTER, ['presentValue']);
+    },
+};
+
 const definition = {
     zigbeeModel: ['AirCube'],
     model: 'AirCube',
@@ -54,8 +81,8 @@ const definition = {
         temperature(),
         humidity(),
     ],
-    fromZigbee: [fzAirCubeAirQuality],
-    toZigbee: [],
+    fromZigbee: [fzAirCubeAirQuality, fzAirCubeBrightness],
+    toZigbee: [tzAirCubeBrightness],
     exposes: [
         e.numeric('eco2', exposes.access.STATE)
             .withUnit('ppm')
@@ -72,13 +99,15 @@ const definition = {
             .withDescription('Air Quality Index')
             .withValueMin(0)
             .withValueMax(500),
+        e.numeric('brightness', exposes.access.ALL)
+            .withDescription('LED brightness')
+            .withValueMin(0)
+            .withValueMax(100),
     ],
     configure: async (device, coordinatorEndpoint) => {
         const endpoint = device.getEndpoint(10);
-        /* Bind standard clusters */
         await endpoint.bind('msTemperatureMeasurement', coordinatorEndpoint);
         await endpoint.bind('msRelativeHumidity', coordinatorEndpoint);
-        /* Configure reporting for standard clusters */
         await endpoint.configureReporting('msTemperatureMeasurement', [{
             attribute: 'measuredValue', minimumReportInterval: 1,
             maximumReportInterval: 60, reportableChange: 50,

--- a/zha/aircube.py
+++ b/zha/aircube.py
@@ -2,24 +2,36 @@
 
 from zigpy.quirks import CustomCluster
 from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant import EntityType
 from zigpy.zcl.foundation import ZCLAttributeDef
 import zigpy.types as t
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+try:
+    from zigpy.quirks.v2.homeassistant.sensor import SensorDeviceClass, SensorStateClass
+except ImportError:
+    from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 
 
 class AirQualityCluster(CustomCluster):
-    """AirCube custom air quality cluster (0xFC01)."""
+    """AirCube custom air quality cluster (0xFC01) — read-only sensors."""
 
     cluster_id = 0xFC01
     name = "AirCube Air Quality"
     ep_attribute = "aircube_air_quality"
 
     class AttributeDefs(CustomCluster.AttributeDefs):
-        eco2 = ZCLAttributeDef(id=0x0000, type=t.uint16_t, is_manufacturer_specific=True)
-        etvoc = ZCLAttributeDef(id=0x0001, type=t.uint16_t, is_manufacturer_specific=True)
-        aqi = ZCLAttributeDef(id=0x0002, type=t.uint16_t, is_manufacturer_specific=True)
+        eco2 = ZCLAttributeDef(
+            id=0x0000, type=t.uint16_t, is_manufacturer_specific=False
+        )
+        etvoc = ZCLAttributeDef(
+            id=0x0001, type=t.uint16_t, is_manufacturer_specific=False
+        )
+        aqi = ZCLAttributeDef(
+            id=0x0002, type=t.uint16_t, is_manufacturer_specific=False
+        )
 
+
+ANALOG_OUTPUT_CLUSTER_ID = 0x000D
 
 (
     QuirkBuilder("StuckAtPrototype", "AirCube")
@@ -29,8 +41,9 @@ class AirQualityCluster(CustomCluster):
         AirQualityCluster.cluster_id,
         endpoint_id=10,
         unit="ppm",
+        device_class=SensorDeviceClass.CO2,
         state_class=SensorStateClass.MEASUREMENT,
-        fallback_name="eCO2",
+        fallback_name="Equivalent CO2",
     )
     .sensor(
         AirQualityCluster.AttributeDefs.etvoc.name,
@@ -39,7 +52,7 @@ class AirQualityCluster(CustomCluster):
         unit="ppb",
         device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
         state_class=SensorStateClass.MEASUREMENT,
-        fallback_name="eTVOC",
+        fallback_name="Volatile organic compounds",
     )
     .sensor(
         AirQualityCluster.AttributeDefs.aqi.name,
@@ -47,7 +60,19 @@ class AirQualityCluster(CustomCluster):
         endpoint_id=10,
         device_class=SensorDeviceClass.AQI,
         state_class=SensorStateClass.MEASUREMENT,
-        fallback_name="AQI",
+        fallback_name="Air quality index",
+    )
+    .number(
+        "present_value",
+        ANALOG_OUTPUT_CLUSTER_ID,
+        endpoint_id=10,
+        min_value=0,
+        max_value=100,
+        step=1,
+        mode="slider",
+        entity_type=EntityType.STANDARD,
+        translation_key="brightness",
+        fallback_name="Brightness",
     )
     .add_to_registry()
 )

--- a/zha/aircube.py
+++ b/zha/aircube.py
@@ -41,7 +41,7 @@ ANALOG_OUTPUT_CLUSTER_ID = 0x000D
         AirQualityCluster.cluster_id,
         endpoint_id=10,
         unit="ppm",
-        device_class=SensorDeviceClass.CO2,
+        translation_key="equivalent_co2",
         state_class=SensorStateClass.MEASUREMENT,
         fallback_name="Equivalent CO2",
     )


### PR DESCRIPTION
- Add LED brightness slider (0–100%) over Zigbee using the standard Analog Output cluster (0x000D), works with both ZHA and Zigbee2MQTT
- Fix ZHA quirk for latest Home Assistant — custom cluster attributes now report correctly instead of showing as Unknown
- Update all documentation and code samples to match