### PR TITLE
Add SmartThings Edge driver and SMARTTHINGS.md setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to AirCube
 
-AirCube is fully open source -- firmware, hardware, desktop software, and Home Assistant integration. Whether you want to fix a bug, add a feature, improve the docs, or port the desktop app to another platform, contributions are welcome.
+AirCube is fully open source -- firmware, hardware, desktop software, Home Assistant integration, and SmartThings Edge driver. Whether you want to fix a bug, add a feature, improve the docs, or port the desktop app to another platform, contributions are welcome.
 
 This document covers everything you need to get the project building on your machine and understand how the code is organized.
 
@@ -12,6 +12,7 @@ This document covers everything you need to get the project building on your mac
 |----------|----------|
 | Customer-facing README | [README.md](README.md) |
 | Home Assistant setup guide | [HOME_ASSISTANT.md](HOME_ASSISTANT.md) |
+| SmartThings setup guide | [SMARTTHINGS.md](SMARTTHINGS.md) |
 | Issue tracker | [GitHub Issues](https://github.com/StuckAtPrototype/AirCube/issues) |
 | License | [Apache 2.0](LICENSE) |
 
@@ -61,8 +62,18 @@ AirCube/
 ├── z2m/                   # Zigbee2MQTT external converter
 │   └── aircube.js
 │
+├── smartthings/           # Samsung SmartThings Edge driver (Zigbee hub)
+│   ├── README.md
+│   ├── driver-channel.json
+│   └── aircube-zigbee/    # Driver package (config, fingerprints, profile, Lua)
+│       ├── config.yml
+│       ├── fingerprints.yml
+│       ├── profiles/
+│       └── src/
+│
 ├── README.md              # Customer-facing product page
 ├── HOME_ASSISTANT.md      # Home Assistant integration guide
+├── SMARTTHINGS.md         # SmartThings hub + CLI integration guide
 ├── CONTRIBUTING.md        # This file
 └── LICENSE                # Apache 2.0
 ```
@@ -228,9 +239,9 @@ The ESP32-H2 has a native IEEE 802.15.4 radio. AirCube registers as a Zigbee End
 | Custom Air Quality | 0xFC01 | `eco2` (0x0000), `etvoc` (0x0001), `aqi` (0x0002) -- all uint16, read-only |
 | Analog Output | 0x000D | `presentValue` (float, 0--100) -- LED brightness, writable |
 
-The custom cluster requires a **ZHA quirk** or **Zigbee2MQTT external converter** on the Home Assistant side. Both are included in the repo (`zha/aircube.py` and `z2m/aircube.js`).
+The custom cluster requires a **ZHA quirk** or **Zigbee2MQTT external converter** on the Home Assistant side. Both are included in the repo (`zha/aircube.py` and `z2m/aircube.js`). On a **Samsung SmartThings** hub, use the Edge driver in `smartthings/aircube-zigbee/` and follow [SMARTTHINGS.md](SMARTTHINGS.md).
 
-See [HOME_ASSISTANT.md](HOME_ASSISTANT.md) for setup instructions.
+See [HOME_ASSISTANT.md](HOME_ASSISTANT.md) for Home Assistant setup instructions.
 
 ### Pairing behavior
 
@@ -333,6 +344,7 @@ Open a [GitHub Issue](https://github.com/StuckAtPrototype/AirCube/issues) with:
 
 ### Ideas for contributions
 
+- **SmartThings** -- driver improvements; WWST certification with Samsung ([certification overview](https://developer.smartthings.com/docs/certification/overview))
 - **New sensor support** -- PM2.5, CO, noise level
 - **Web dashboard** -- local web server on the ESP32-H2 or a companion app
 - **macOS / Linux tray app** -- the current tray app is Windows-only

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # AirCube
 
-**Know your air.** AirCube is a desktop air quality monitor with built-in **Home Assistant** support. It tracks temperature, humidity, eCO2, TVOC, and AQI -- showing air quality as a single, glanceable LED color and reporting every reading to your smart home over **Zigbee**.
+**Know your air.** AirCube is a desktop air quality monitor with built-in **Home Assistant** and **Samsung SmartThings** (Zigbee hub) support. It tracks temperature, humidity, eCO2, TVOC, and AQI -- showing air quality as a single, glanceable LED color and reporting every reading to your smart home over **Zigbee**.
 
-Works standalone out of the box. Pairs with Home Assistant in minutes.
+Works standalone out of the box. Pairs with Home Assistant or a SmartThings-compatible hub in minutes.
 
 [Watch the demo](https://youtu.be/m12KpLyLCrw) (early build -- Home Assistant integration came after this video)
 
@@ -41,7 +41,7 @@ That's it. AirCube works out of the box with no setup, no accounts, and no Wi-Fi
 | **Temperature** | Room temperature in Celsius |
 | **Humidity** | Relative humidity percentage |
 
-The LED color is based on the AQI value. To see the individual numbers, connect to a computer or to Home Assistant.
+The LED color is based on the AQI value. To see the individual numbers, connect to a computer, to Home Assistant, or to SmartThings (with the Edge driver described below).
 
 ---
 
@@ -59,6 +59,16 @@ Once connected you can:
 **Works with** ZHA (built-in) and Zigbee2MQTT.
 
 **Full setup guide:** **[Connecting AirCube to Home Assistant](HOME_ASSISTANT.md)**
+
+---
+
+## SmartThings Integration
+
+AirCube can join a **Samsung SmartThings** Zigbee hub over **Zigbee** (no Wi-Fi configuration on the device). The hub must support **SmartThings Edge**.
+
+By default, SmartThings may only show **temperature** and **humidity** until you install the **AirCube Zigbee** Edge driver from this repository and assign it to the device.
+
+**Full setup guide:** **[Connecting AirCube to SmartThings](SMARTTHINGS.md)** (pairing, SmartThings CLI, driver channel, verification in the app and [Advanced Web App](https://my.smartthings.com/advanced)).
 
 ---
 
@@ -135,11 +145,14 @@ Latest release: [GitHub Releases](https://github.com/StuckAtPrototype/AirCube/re
 - Hold the button for 3 seconds to enter pairing mode (LED flashes blue).
 - Move AirCube closer to the coordinator during pairing.
 
+**SmartThings: only temperature and humidity**
+- Install the **AirCube Zigbee** Edge driver from [`smartthings/aircube-zigbee/`](smartthings/aircube-zigbee/) and assign it to the device. See **[SMARTTHINGS.md](SMARTTHINGS.md)**.
+
 ---
 
 ## Open Source
 
-AirCube is fully open source -- firmware, PCB design, enclosure, desktop software, and Home Assistant integration. Everything is in this repository under the Apache 2.0 license.
+AirCube is fully open source -- firmware, PCB design, enclosure, desktop software, Home Assistant integration, and SmartThings Edge driver. Everything is in this repository under the Apache 2.0 license.
 
 **Developers and makers:** See the **[Contributing Guide](CONTRIBUTING.md)** for build instructions, architecture docs, serial protocol reference, and how to submit changes.
 
@@ -148,5 +161,6 @@ AirCube is fully open source -- firmware, PCB design, enclosure, desktop softwar
 | [Contributing Guide](CONTRIBUTING.md) | Build from source, firmware architecture, serial protocol, how to contribute |
 | [Firmware Update Guide](FIRMWARE_UPDATE.md) | Update your AirCube firmware from a browser |
 | [Home Assistant Guide](HOME_ASSISTANT.md) | ZHA and Zigbee2MQTT setup |
+| [SmartThings Guide](SMARTTHINGS.md) | Samsung hub, Edge driver, CLI setup |
 | [GitHub Issues](https://github.com/StuckAtPrototype/AirCube/issues) | Bug reports and feature requests |
 | [License](LICENSE) | Apache 2.0 |

--- a/SMARTTHINGS.md
+++ b/SMARTTHINGS.md
@@ -1,0 +1,217 @@
+# Connecting AirCube to SmartThings (Samsung hub)
+
+This guide walks you through pairing AirCube to a **SmartThings-compatible Zigbee hub** and installing the community **AirCube Zigbee** Edge driver so you get **temperature, humidity, eCO2, eTVOC, and AQI** in the SmartThings app.
+
+> **Default behavior:** Without this driver, SmartThings often joins AirCube as a generic **humidity / temperature** device. You only get **temp and humidity**. The Edge driver adds the **air quality** sensors over Zigbee cluster `0xFC01` (same idea as the [ZHA quirk](zha/aircube.py) and [Zigbee2MQTT converter](z2m/aircube.js)).
+
+**You will need**
+
+- AirCube powered over USB-C
+- A **SmartThings Edge**–capable hub (e.g. SmartThings v3, Aeotec Smart Home Hub, SmartThings Station) on your Samsung account
+- A **Mac, Windows, or Linux PC** for the [SmartThings CLI](https://github.com/SmartThingsCommunity/smartthings-cli) (one-time driver install)
+- A [Samsung account](https://account.samsung.com/) used with SmartThings
+
+The first time the CLI needs your SmartThings account, it **starts a browser sign-in** automatically (you may not see a separate `login` subcommand in `smartthings --help`). You do **not** need to create a Personal Access Token in the developer portal for normal interactive use. For **automation / CI**, you can use a [PAT](https://developer.smartthings.com/docs/personal-access-tokens) with channel scopes — see [driver channels](https://developer.smartthings.com/docs/devices/hub-connected/driver-channels).
+
+---
+
+## Step 1 — Put AirCube in pairing mode
+
+1. Plug in AirCube (or, if already powered, use the next step).
+2. **Hold the button for about 3 seconds** until the LEDs **flash blue** (Zigbee pairing mode).
+
+See the [README](README.md) LED / button table if you need a refresher.
+
+---
+
+## Step 2 — Add AirCube in the SmartThings mobile app
+
+1. Open the **SmartThings** app → **Add device** (or **+**).
+2. Choose **Scan nearby** / **Zigbee** / **Generic Zigbee device** per your app version, and enable **pairing** on the hub when prompted.
+3. Wait until AirCube appears and finish naming / room assignment.
+
+**Check:** Open the new device — you should see **temperature** and **humidity**.  
+**eCO2, TVOC, and AQI will not appear yet** until the **AirCube Zigbee** driver is installed and selected (next steps).
+
+---
+
+## Step 3 — Install the SmartThings CLI (sign-in is automatic)
+
+1. Install the CLI using the [official instructions](https://github.com/SmartThingsCommunity/smartthings-cli) for your OS (Homebrew on Mac: `brew install smartthings`).
+2. Run `smartthings --version` and confirm the command works.
+
+**Authentication:** Many recent builds do **not** list a `smartthings login` command. The **first command that calls the SmartThings API** (for example **`smartthings edge:drivers:package .`** in Step 5) will **open a browser** so you can sign in with your Samsung account. Complete that flow once; later CLI commands reuse the session.
+
+- To **sign out** on this machine: `smartthings logout` (then the next API command will prompt for login again).
+- **Optional:** Headless or automation-only setups can use a **Personal Access Token** instead; see [CLI authentication](https://developer.smartthings.com/docs/sdks/cli/).
+
+---
+
+## Step 4 — Get the Edge driver source
+
+From your clone of **this repository** (folder name may differ):
+
+```bash
+cd smartthings/aircube-zigbee
+```
+
+If you have not cloned yet:
+
+```bash
+git clone https://github.com/StuckAtPrototype/AirCube.git
+cd AirCube/smartthings/aircube-zigbee
+```
+
+That directory contains `config.yml`, `fingerprints.yml`, `profiles/`, and `src/init.lua`.
+
+---
+
+## Step 5 — Package the driver (build + upload)
+
+From `smartthings/aircube-zigbee`:
+
+```bash
+smartthings edge:drivers:package .
+```
+
+The **first** time you run this (or any API command), the CLI may **open the browser** for Samsung sign-in — complete it, then re-run `package` if needed.
+
+The CLI prints a **Driver Id** and **Version** (timestamp string). **Save both** — you need them to assign the driver to a channel.
+
+Optional: also write a local zip:
+
+```bash
+smartthings edge:drivers:package . -b ./aircube-zigbee.zip
+```
+
+> Recent CLI versions **upload** the driver when you package; there is **no** separate `publish` command.
+
+---
+
+## Step 6 — Create a driver channel (first time only)
+
+You need a **driver channel** to install your own driver on the hub.
+
+1. Create a JSON file (example below) — e.g. `channel.json` in any folder.
+
+```json
+{
+  "name": "My AirCube test channel",
+  "description": "Private channel for AirCube Edge driver",
+  "termsOfServiceUrl": "https://example.com",
+  "type": "DRIVER"
+}
+```
+
+2. Run:
+
+```bash
+smartthings edge:channels:create -i channel.json
+```
+
+3. List channels and copy your **channel id** (UUID):
+
+```bash
+smartthings edge:channels
+```
+
+An example template is also in [`smartthings/channel-driver-example.json`](smartthings/channel-driver-example.json).
+
+---
+
+## Step 7 — Assign the packaged driver to your channel
+
+```bash
+smartthings edge:channels:assign <DRIVER_ID> "<VERSION>" --channel <CHANNEL_ID>
+```
+
+Use the **Driver Id** and **Version** from Step 5. You can omit arguments and use **interactive prompts** instead.
+
+---
+
+## Step 8 — Enroll your hub, then install the driver
+
+**Order matters:** enroll the hub on the channel **before** install.
+
+```bash
+smartthings edge:channels:enroll --channel <CHANNEL_ID>
+```
+
+Pick your hub when prompted (or pass flags if your CLI supports them).
+
+Then install the driver **onto that hub** from the same channel:
+
+```bash
+smartthings edge:drivers:install --channel <CHANNEL_ID> --hub <HUB_DEVICE_UUID>
+```
+
+### Hub id must be a UUID
+
+`<HUB_DEVICE_UUID>` looks like `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. It is **not** the sticker MAC, Zigbee EUI, or `networkId` string.
+
+**Where to find it**
+
+- [SmartThings Advanced Web App](https://my.smartthings.com/advanced) → open your **hub** as a device → copy **Device id**, **or**
+- Open any Zigbee child device (e.g. AirCube) → **Parent device** / hub → copy that hub’s id.
+
+If you omit `--hub`, the CLI usually offers a **list** — picking from the list avoids typos.
+
+If install returns **HTTP 400**, see [Troubleshooting](#troubleshooting) below.
+
+---
+
+## Step 9 — Use the AirCube Zigbee driver for your device
+
+The hub must run **AirCube Zigbee** instead of the generic **Zigbee Humidity Sensor** driver.
+
+**Option A — Switch driver (keep device / room)**
+
+```bash
+smartthings edge:drivers:switch <DEVICE_ID>
+```
+
+Use the AirCube **device** id from the Advanced Web App (not the hub id). Follow prompts to select **AirCube Zigbee**.
+
+**Option B — Remove and re-pair**
+
+Remove AirCube from SmartThings, then add it again (Step 2) **after** the driver is installed on the hub. With a matching fingerprint, SmartThings should pick **AirCube Zigbee** automatically.
+
+---
+
+## Step 10 — Confirm in the Advanced Web App
+
+1. Open [SmartThings Advanced Web App](https://my.smartthings.com/advanced).
+2. Select **AirCube**.
+3. Check **Driver** (or device summary): it should show **AirCube Zigbee** (or your packaged driver name), not only “Zigbee Humidity Sensor”.
+4. Under capabilities / state, you should eventually see **carbon dioxide**, **TVOC**, and **air quality** style attributes after reports arrive (allow a few minutes for sensor warm-up).
+
+---
+
+## Step 11 — Confirm in the mobile app
+
+Open the device card: you should see **temperature**, **humidity**, **CO₂**, **TVOC**, and **air quality** (labels may vary slightly by app version).
+
+Gas sensors may read **0** for the first few minutes after power-on — that is normal while the ENS16x warms up (same as [Home Assistant](HOME_ASSISTANT.md)).
+
+---
+
+## Troubleshooting
+
+| Problem | What to try |
+|---------|-------------|
+| Only temp / humidity | Driver not applied — repeat [Step 9](#step-9--use-the-aircube-zigbee-driver-for-your-device). |
+| `drivers:install` **400 Bad Request** | Use **hub UUID**, not sticker id. Run **`channels:enroll`** for the same channel first. |
+| eCO2 / TVOC / AQI stuck at 0 | Wait **3–5+ minutes** after power-on. Ensure driver is **AirCube Zigbee** and hub is **online**. |
+| CLI / channel errors | Run `smartthings logout` then repeat the command that triggered login (browser). If you use a **PAT** instead, confirm it includes **channel** read/write. See [driver channels](https://developer.smartthings.com/docs/devices/hub-connected/driver-channels). |
+
+---
+
+## Technical reference
+
+Zigbee layout (endpoint **10**): standard temp/humidity clusters; custom air quality cluster **`0xFC01`**; LED brightness uses Analog Output **`0x000D`** (not exposed in this driver v1). Details match [CONTRIBUTING.md](CONTRIBUTING.md) → *Zigbee Integration*.
+
+---
+
+## Contributors
+
+If you improve the Edge driver or this guide, open a **pull request** on the [AirCube](https://github.com/StuckAtPrototype/AirCube) repository so all users get the update.

--- a/SMARTTHINGS.md
+++ b/SMARTTHINGS.md
@@ -92,30 +92,19 @@ smartthings edge:drivers:package . -b ./aircube-zigbee.zip
 
 You need a **driver channel** to install your own driver on the hub.
 
-1. Create a JSON file (example below) — e.g. `channel.json` in any folder.
+This repo ships [`smartthings/driver-channel.json`](smartthings/driver-channel.json) for `edge:channels:create`. It points **`termsOfServiceUrl`** at the StuckAtPrototype **[Terms of Service](https://stuckatprototype.com/policies/terms-of-service)**. Edit **`name`** / **`description`** in that file if you want different labels on your channel.
 
-```json
-{
-  "name": "My AirCube test channel",
-  "description": "Private channel for AirCube Edge driver",
-  "termsOfServiceUrl": "https://example.com",
-  "type": "DRIVER"
-}
-```
-
-2. Run:
+From the **repository root** (the folder that contains `smartthings/`):
 
 ```bash
-smartthings edge:channels:create -i channel.json
+smartthings edge:channels:create -i smartthings/driver-channel.json
 ```
 
-3. List channels and copy your **channel id** (UUID):
+List channels and copy your **channel id** (UUID):
 
 ```bash
 smartthings edge:channels
 ```
-
-An example template is also in [`smartthings/channel-driver-example.json`](smartthings/channel-driver-example.json).
 
 ---
 

--- a/smartthings/README.md
+++ b/smartthings/README.md
@@ -9,7 +9,7 @@ This folder contains the **AirCube Zigbee** Edge driver source for Samsung Smart
 ```text
 smartthings/
 ├── README.md                 # This file
-├── channel-driver-example.json   # Template for edge:channels:create
+├── driver-channel.json       # Input for `edge:channels:create -i` (TOS URL preset)
 └── aircube-zigbee/           # Driver package (config, fingerprints, profile, Lua)
     ├── config.yml
     ├── fingerprints.yml

--- a/smartthings/README.md
+++ b/smartthings/README.md
@@ -1,0 +1,18 @@
+# SmartThings Edge driver (Zigbee)
+
+This folder contains the **AirCube Zigbee** Edge driver source for Samsung SmartThings hubs.
+
+**User setup:** see **[SMARTTHINGS.md](../SMARTTHINGS.md)** in the repository root for step-by-step pairing, CLI install, channel workflow, and verification in the app and [Advanced Web App](https://my.smartthings.com/advanced).
+
+**Layout**
+
+```text
+smartthings/
+├── README.md                 # This file
+├── channel-driver-example.json   # Template for edge:channels:create
+└── aircube-zigbee/           # Driver package (config, fingerprints, profile, Lua)
+    ├── config.yml
+    ├── fingerprints.yml
+    ├── profiles/
+    └── src/
+```

--- a/smartthings/aircube-zigbee/config.yml
+++ b/smartthings/aircube-zigbee/config.yml
@@ -1,0 +1,6 @@
+name: 'AirCube Zigbee'
+packageKey: 'aircube-zigbee'
+permissions:
+  zigbee: {}
+description: 'StuckAtPrototype AirCube air quality monitor (temperature, humidity, eCO2, eTVOC, AQI)'
+vendorSupportInformation: 'https://github.com/StuckAtPrototype/AirCube'

--- a/smartthings/aircube-zigbee/fingerprints.yml
+++ b/smartthings/aircube-zigbee/fingerprints.yml
@@ -1,0 +1,6 @@
+zigbeeManufacturer:
+  - id: StuckAtPrototype/AirCube
+    deviceLabel: AirCube
+    manufacturer: StuckAtPrototype
+    model: AirCube
+    deviceProfileName: aircube-air-quality

--- a/smartthings/aircube-zigbee/profiles/aircube-air-quality.yml
+++ b/smartthings/aircube-zigbee/profiles/aircube-air-quality.yml
@@ -1,0 +1,20 @@
+name: aircube-air-quality
+components:
+  - id: main
+    capabilities:
+      - id: temperatureMeasurement
+        version: 1
+      - id: relativeHumidityMeasurement
+        version: 1
+      - id: carbonDioxideMeasurement
+        version: 1
+      - id: tvocMeasurement
+        version: 1
+      - id: airQualitySensor
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+      - name: AirQualityDetector

--- a/smartthings/aircube-zigbee/src/init.lua
+++ b/smartthings/aircube-zigbee/src/init.lua
@@ -1,0 +1,164 @@
+-- Copyright 2026 SmartThings Community contributors
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- AirCube (StuckAtPrototype) — custom cluster 0xFC01 for eCO2, eTVOC, AQI.
+-- Reference: https://github.com/StuckAtPrototype/AirCube
+
+local capabilities = require "st.capabilities"
+local ZigbeeDriver = require "st.zigbee"
+local defaults = require "st.zigbee.defaults"
+local clusters = require "st.zigbee.zcl.clusters"
+local data_types = require "st.zigbee.data_types"
+local device_management = require "st.zigbee.device_management"
+local cluster_base = require "st.zigbee.cluster_base"
+
+local TemperatureMeasurement = clusters.TemperatureMeasurement
+local RelativeHumidity = clusters.RelativeHumidity
+
+--- ZCL data type ID for unsigned 16-bit (same as RelativeHumidity measured value).
+local UINT16_ZCL_TYPE = RelativeHumidity.attributes.MeasuredValue.base_type.ID
+
+--- AirCube exposes sensor clusters on endpoint 10 (firmware / ZHA quirk).
+local AIRCUBE_ENDPOINT = 0x0A
+
+--- Custom air quality cluster (same as ZHA quirk / Zigbee2MQTT converter).
+local AIRCUBE_AQ_CLUSTER = 0xFC01
+local ATTR_ECO2 = 0x0000
+local ATTR_ETVOC = 0x0001
+local ATTR_AQI = 0x0002
+
+--- Reporting for 0xFC01 (intervals and deltas aligned with AirCube / Z2M example).
+local AIRCUBE_AQ_REPORTING = {
+  { attribute = ATTR_ECO2, min_rep = 1, max_rep = 600, rep_change = 50 },
+  { attribute = ATTR_ETVOC, min_rep = 1, max_rep = 600, rep_change = 1 },
+  { attribute = ATTR_AQI, min_rep = 1, max_rep = 600, rep_change = 5 },
+}
+
+local function emit_eco2(driver, device, value, zb_rx)
+  if value.value ~= nil and value.value < 65535 then
+    device:emit_event(capabilities.carbonDioxideMeasurement.carbonDioxide({ value = value.value, unit = "ppm" }))
+  end
+end
+
+local function emit_etvoc(driver, device, value, zb_rx)
+  if value.value ~= nil and value.value < 65535 then
+    device:emit_event(capabilities.tvocMeasurement.tvocLevel({ value = value.value, unit = "ppb" }))
+  end
+end
+
+local function emit_aqi(driver, device, value, zb_rx)
+  if value.value ~= nil and value.value < 65535 then
+    device:emit_event(capabilities.airQualitySensor.airQuality({ value = value.value }))
+  end
+end
+
+local function aircube_refresh(driver, device)
+  device:refresh()
+end
+
+local function aircube_init(driver, device)
+  for _, cfg in ipairs(AIRCUBE_AQ_REPORTING) do
+    device:add_configured_attribute({
+      cluster = AIRCUBE_AQ_CLUSTER,
+      attribute = cfg.attribute,
+      minimum_interval = cfg.min_rep,
+      maximum_interval = cfg.max_rep,
+      data_type = data_types.Uint16,
+      reportable_change = cfg.rep_change,
+    })
+  end
+end
+
+local function aircube_configure(driver, device)
+  device:configure()
+
+  -- Bind air-quality cluster to the hub on the correct endpoint.
+  device:send(
+    device_management.build_bind_request(
+      device,
+      AIRCUBE_AQ_CLUSTER,
+      driver.environment_info.hub_zigbee_eui,
+      AIRCUBE_ENDPOINT
+    )
+  )
+
+  -- Bind standard measurement clusters (matches Zigbee2MQTT configure in AirCube docs).
+  device:send(
+    device_management.build_bind_request(
+      device,
+      TemperatureMeasurement.ID,
+      driver.environment_info.hub_zigbee_eui,
+      AIRCUBE_ENDPOINT
+    )
+  )
+  device:send(
+    device_management.build_bind_request(
+      device,
+      RelativeHumidity.ID,
+      driver.environment_info.hub_zigbee_eui,
+      AIRCUBE_ENDPOINT
+    )
+  )
+
+  for _, cfg in ipairs(AIRCUBE_AQ_REPORTING) do
+    device:send(
+      cluster_base.configure_reporting(
+        device,
+        data_types.ClusterId(AIRCUBE_AQ_CLUSTER),
+        cfg.attribute,
+        UINT16_ZCL_TYPE,
+        cfg.min_rep,
+        cfg.max_rep,
+        cfg.rep_change
+      ):to_endpoint(AIRCUBE_ENDPOINT)
+    )
+  end
+
+  -- Ensure temp/humidity reports use endpoint 10 (Z2M-style intervals).
+  device:send(
+    TemperatureMeasurement.attributes.MeasuredValue:configure_reporting(device, 1, 60, 50):to_endpoint(AIRCUBE_ENDPOINT)
+  )
+  device:send(
+    RelativeHumidity.attributes.MeasuredValue:configure_reporting(device, 1, 60, 100):to_endpoint(AIRCUBE_ENDPOINT)
+  )
+
+  device.thread:call_with_delay(2, function()
+    device:send(TemperatureMeasurement.attributes.MeasuredValue:read(device):to_endpoint(AIRCUBE_ENDPOINT))
+    device:send(RelativeHumidity.attributes.MeasuredValue:read(device):to_endpoint(AIRCUBE_ENDPOINT))
+  end)
+end
+
+local aircube_driver_template = {
+  supported_capabilities = {
+    capabilities.temperatureMeasurement,
+    capabilities.relativeHumidityMeasurement,
+  },
+  lifecycle_handlers = {
+    init = aircube_init,
+    doConfigure = aircube_configure,
+  },
+  capability_handlers = {
+    [capabilities.refresh.ID] = {
+      [capabilities.refresh.commands.refresh.NAME] = aircube_refresh,
+    },
+  },
+  zigbee_handlers = {
+    attr = {
+      [AIRCUBE_AQ_CLUSTER] = {
+        [ATTR_ECO2] = emit_eco2,
+        [ATTR_ETVOC] = emit_etvoc,
+        [ATTR_AQI] = emit_aqi,
+      },
+    },
+  },
+  health_check = false,
+}
+
+defaults.register_for_default_handlers(
+  aircube_driver_template,
+  aircube_driver_template.supported_capabilities,
+  { native_capability_attrs_enabled = true }
+)
+
+local driver = ZigbeeDriver("aircube-zigbee", aircube_driver_template)
+driver:run()

--- a/smartthings/channel-driver-example.json
+++ b/smartthings/channel-driver-example.json
@@ -1,0 +1,6 @@
+{
+  "name": "AirCube private driver channel",
+  "description": "Channel for StuckAtPrototype AirCube Edge driver (personal / beta testing)",
+  "termsOfServiceUrl": "https://www.apache.org/licenses/LICENSE-2.0",
+  "type": "DRIVER"
+}

--- a/smartthings/channel-driver-example.json
+++ b/smartthings/channel-driver-example.json
@@ -1,6 +1,0 @@
-{
-  "name": "AirCube private driver channel",
-  "description": "Channel for StuckAtPrototype AirCube Edge driver (personal / beta testing)",
-  "termsOfServiceUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-  "type": "DRIVER"
-}

--- a/smartthings/driver-channel.json
+++ b/smartthings/driver-channel.json
@@ -1,0 +1,6 @@
+{
+  "name": "AirCube private driver channel",
+  "description": "Channel for StuckAtPrototype AirCube Edge driver (personal / beta testing)",
+  "termsOfServiceUrl": "https://stuckatprototype.com/policies/terms-of-service",
+  "type": "DRIVER"
+}


### PR DESCRIPTION
## Summary

Adds a Samsung **SmartThings** path for AirCube on **Zigbee hubs that support Edge**: Lua driver under `smartthings/aircube-zigbee/`, user guide **`SMARTTHINGS.md`** (pairing, CLI package/channel/install, Advanced Web App check), and **`smartthings/driver-channel.json`** for `edge:channels:create` with StuckAtPrototype **Terms of Service** URL.

Updates **README** and **CONTRIBUTING** (SmartThings section, project layout, Zigbee note).

## Why

Out of the box the hub often matches AirCube as a generic humidity/temperature device. Custom cluster **0xFC01** (eCO2, eTVOC, AQI) needs an explicit Edge driver; behavior is aligned with existing **ZHA** / **Z2M** integration in this repo.

## How to verify

1. Pair AirCube, confirm temp/humidity in the app.
2. From repo root: `smartthings edge:drivers:package .` in `smartthings/aircube-zigbee/`, assign to a channel, enroll hub, install driver, switch driver or re-pair.
3. Confirm **AirCube Zigbee** driver and all five readings in the app / Advanced Web App.

## Notes

- LED brightness (**Analog Output 0x000D**) is not in this driver v1.
- Apache-2.0 consistent with the rest of the project.

<img width="576" height="988" alt="IMG_6058" src="https://github.com/user-attachments/assets/db3169f7-cae0-4e35-ae3f-d274857992b9" />

<img width="1229" height="1174" alt="Screenshot 2026-04-08 at 12 48 14 PM" src="https://github.com/user-attachments/assets/b88d23c3-a5f3-40b4-8bfc-0522a10993d4" />

