### PR TITLE
Round reported Zigbee brightness percentage

### DIFF
--- a/firmware/main/zigbee.c
+++ b/firmware/main/zigbee.c
@@ -114,7 +114,14 @@ static void init_sw_build_id(void)
 
 static float current_brightness_percent(void)
 {
-    return led_get_intensity() * 100.0f;
+    float pct = led_get_intensity() * 100.0f;
+    if (pct < 0.0f) {
+        return 0.0f;
+    }
+    if (pct > 100.0f) {
+        return 100.0f;
+    }
+    return (float)((uint8_t)(pct + 0.5f));
 }
 
 static void report_attr(uint16_t cluster_id, uint16_t attr_id)


### PR DESCRIPTION
## Summary

Fix the ZHA long-decimal brightness value reported in #28 by rounding the firmware-reported Zigbee brightness percentage to a whole number.

## Background

#36 fixed related brightness sync behavior and added rounding in the Zigbee2MQTT converters. However, ZHA does not use the Zigbee2MQTT converter, so it does not benefit from that converter-side rounding.

The ZHA quirk exposes the firmware’s Analog Output `present_value` attribute through Zigpy/Home Assistant. The firmware currently derives that value from:

```c
led_get_intensity() * 100.0f
```

Because `led_get_intensity()` is a `0.0f` to `1.0f` float, values like `0.3f` or `0.6f` can become `30.0000019` or `60.0000038` when reported as a percentage.

## Change

Clamp and round `current_brightness_percent()` so the firmware reports a clean whole-number percentage from `0` to `100`.

This only changes the value reported over Zigbee. It does not change internal LED intensity behavior or brightness persistence behavior.

## Verification

Built locally with ESP-IDF 5.5.3:

```bash
cd firmware
idf.py set-target esp32h2 build
```

Build completed successfully and generated `firmware/build/AirCube.bin`.