### PR TITLE
Add BTHome v2 BLE broadcaster for Home Assistant

### DIFF
--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -9,6 +9,8 @@ idf_component_register(SRCS "main.c"
                                 "button.c"
                                 "history.c"
                                 "zigbee.c"
+                                "ble_bthome.c"
                        PRIV_REQUIRES spi_flash esp_partition esp_timer esp_driver_rmt esp_driver_i2c esp_driver_uart esp_driver_usb_serial_jtag vfs esp_pm esp_driver_gpio nvs_flash esp_app_format
                                      espressif__esp-zigbee-lib espressif__esp-zboss-lib
+                                     bt
                        INCLUDE_DIRS "")

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -10,7 +10,6 @@ idf_component_register(SRCS "main.c"
                                 "history.c"
                                 "zigbee.c"
                                 "ble_bthome.c"
-                       PRIV_REQUIRES spi_flash esp_partition esp_timer esp_driver_rmt esp_driver_i2c esp_driver_uart esp_driver_usb_serial_jtag vfs esp_pm esp_driver_gpio nvs_flash esp_app_format
+                       PRIV_REQUIRES spi_flash esp_partition esp_timer esp_driver_rmt esp_driver_i2c esp_driver_uart esp_driver_usb_serial_jtag vfs esp_pm esp_driver_gpio nvs_flash esp_app_format bt
                                      espressif__esp-zigbee-lib espressif__esp-zboss-lib
-                                     bt
                        INCLUDE_DIRS "")

--- a/firmware/main/ble_bthome.c
+++ b/firmware/main/ble_bthome.c
@@ -45,11 +45,11 @@ static const char *TAG = "ble_bthome";
 #define BTHOME_OBJ_CO2          0x12  // uint16 ppm
 #define BTHOME_OBJ_TVOC         0x13  // uint16 µg/m³ (we send ppb)
 
-static bool     s_ble_ready  = false;
-static int16_t  s_temp_x100  = 2000;  // 20.00 °C until first update
-static uint16_t s_hum_x100   = 5000;  // 50.00 %
-static uint16_t s_co2        = 0;
-static uint16_t s_tvoc       = 0;
+static volatile bool     s_ble_ready  = false;
+static volatile int16_t  s_temp_x100  = 2000;  // 20.00 °C until first update
+static volatile uint16_t s_hum_x100   = 5000;  // 50.00 %
+static volatile uint16_t s_co2        = 0;
+static volatile uint16_t s_tvoc       = 0;
 
 // ---------------------------------------------------------------------------
 // Advertising helpers

--- a/firmware/main/ble_bthome.c
+++ b/firmware/main/ble_bthome.c
@@ -30,7 +30,6 @@
 #include "nimble/nimble_port_freertos.h"
 #include "host/ble_hs.h"
 #include "host/ble_gap.h"
-#include "services/gap/ble_svc_gap.h"
 
 static const char *TAG = "ble_bthome";
 
@@ -167,9 +166,6 @@ void ble_bthome_init(void)
 
     ble_hs_cfg.sync_cb  = on_sync;
     ble_hs_cfg.reset_cb = on_reset;
-
-    ble_svc_gap_init();
-    ble_svc_gap_device_name_set("AirCube");
 
     nimble_port_freertos_init(ble_host_task);
     ESP_LOGI(TAG, "BLE BTHome module initialized");

--- a/firmware/main/ble_bthome.c
+++ b/firmware/main/ble_bthome.c
@@ -1,0 +1,193 @@
+/**
+ * @file ble_bthome.c
+ * @brief BLE BTHome v2 broadcaster for AirCube
+ *
+ * Builds a non-connectable BLE advertisement in BTHome v2 format and
+ * updates it whenever sensor_task calls ble_bthome_update(). Home
+ * Assistant's Bluetooth integration auto-discovers the device through
+ * any nearby Bluetooth proxy.
+ *
+ * BTHome v2 spec: https://bthome.io/format/
+ *
+ * Advertisement layout:
+ *   AD[0] Flags (0x01)            : 0x06
+ *   AD[1] Service Data (0x16)     : UUID 0xFCD2 + device info + objects
+ *   Scan Response: Complete Local Name (0x09) : "AirCube"
+ *
+ * BTHome service data payload (object IDs must be in ascending order):
+ *   0x40            device info byte (no encryption, v2)
+ *   0x02  sint16    temperature * 100 (°C)
+ *   0x03  uint16    humidity    * 100 (%)
+ *   0x12  uint16    eCO2 (ppm)
+ *   0x13  uint16    eTVOC (ppb — BTHome labels unit as µg/m³)
+ */
+
+#include "ble_bthome.h"
+
+#include <string.h>
+#include "esp_log.h"
+#include "nimble/nimble_port.h"
+#include "nimble/nimble_port_freertos.h"
+#include "host/ble_hs.h"
+#include "host/ble_gap.h"
+#include "services/gap/ble_svc_gap.h"
+
+static const char *TAG = "ble_bthome";
+
+// BTHome v2 service UUID: 0xFCD2
+#define BTHOME_UUID_LSB     0xD2
+#define BTHOME_UUID_MSB     0xFC
+// Device info: no encryption (bit 0 = 0), BTHome version 2 (bits 7:5 = 010)
+#define BTHOME_DEVICE_INFO  0x40
+
+// Object IDs — must appear in ascending order in the payload
+#define BTHOME_OBJ_TEMPERATURE  0x02  // sint16 * 0.01 °C
+#define BTHOME_OBJ_HUMIDITY     0x03  // uint16 * 0.01 %
+#define BTHOME_OBJ_CO2          0x12  // uint16 ppm
+#define BTHOME_OBJ_TVOC         0x13  // uint16 µg/m³ (we send ppb)
+
+static bool     s_ble_ready  = false;
+static int16_t  s_temp_x100  = 2000;  // 20.00 °C until first update
+static uint16_t s_hum_x100   = 5000;  // 50.00 %
+static uint16_t s_co2        = 0;
+static uint16_t s_tvoc       = 0;
+
+// ---------------------------------------------------------------------------
+// Advertising helpers
+// ---------------------------------------------------------------------------
+
+static void do_advertise(void)
+{
+    // ── Build advertisement payload ──────────────────────────────────────
+    uint8_t adv[31];
+    int pos = 0;
+
+    // AD: Flags
+    adv[pos++] = 2;
+    adv[pos++] = 0x01;
+    adv[pos++] = 0x06;  // LE General Discoverable | BR/EDR Not Supported
+
+    // BTHome v2 service data (UUID + device info + objects)
+    uint8_t svc[20];
+    int sp = 0;
+    svc[sp++] = BTHOME_UUID_LSB;
+    svc[sp++] = BTHOME_UUID_MSB;
+    svc[sp++] = BTHOME_DEVICE_INFO;
+
+    int16_t t = s_temp_x100;
+    svc[sp++] = BTHOME_OBJ_TEMPERATURE;
+    svc[sp++] = (uint8_t)((uint16_t)t & 0xFF);
+    svc[sp++] = (uint8_t)((uint16_t)t >> 8);
+
+    svc[sp++] = BTHOME_OBJ_HUMIDITY;
+    svc[sp++] = (uint8_t)(s_hum_x100 & 0xFF);
+    svc[sp++] = (uint8_t)(s_hum_x100 >> 8);
+
+    svc[sp++] = BTHOME_OBJ_CO2;
+    svc[sp++] = (uint8_t)(s_co2 & 0xFF);
+    svc[sp++] = (uint8_t)(s_co2 >> 8);
+
+    svc[sp++] = BTHOME_OBJ_TVOC;
+    svc[sp++] = (uint8_t)(s_tvoc & 0xFF);
+    svc[sp++] = (uint8_t)(s_tvoc >> 8);
+
+    // AD: Service Data - 16-bit UUID (type 0x16)
+    adv[pos++] = sp + 1;  // length = payload bytes + type byte
+    adv[pos++] = 0x16;
+    memcpy(adv + pos, svc, sp);
+    pos += sp;
+
+    int rc = ble_gap_adv_set_data(adv, pos);
+    if (rc != 0) {
+        ESP_LOGE(TAG, "ble_gap_adv_set_data failed: %d", rc);
+        return;
+    }
+
+    // ── Scan response: device name ───────────────────────────────────────
+    uint8_t rsp[31];
+    int rp = 0;
+    const char *name = "AirCube";
+    uint8_t nlen = (uint8_t)strlen(name);
+    rsp[rp++] = nlen + 1;
+    rsp[rp++] = 0x09;  // Complete Local Name
+    memcpy(rsp + rp, name, nlen);
+    rp += nlen;
+    ble_gap_adv_rsp_set_data(rsp, rp);
+
+    // ── Start non-connectable advertising ────────────────────────────────
+    struct ble_gap_adv_params params = {0};
+    params.conn_mode = BLE_GAP_CONN_MODE_NON;
+    params.disc_mode = BLE_GAP_DISC_MODE_GEN;
+    // 500 – 1000 ms interval: low enough for HA discovery, friendly to Zigbee coex
+    params.itvl_min  = BLE_GAP_ADV_ITVL_MS(500);
+    params.itvl_max  = BLE_GAP_ADV_ITVL_MS(1000);
+
+    rc = ble_gap_adv_start(BLE_OWN_ADDR_PUBLIC, NULL, BLE_HS_FOREVER,
+                           &params, NULL, NULL);
+    if (rc != 0 && rc != BLE_HS_EALREADY) {
+        ESP_LOGE(TAG, "ble_gap_adv_start failed: %d", rc);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NimBLE host callbacks
+// ---------------------------------------------------------------------------
+
+static void on_sync(void)
+{
+    s_ble_ready = true;
+    ESP_LOGI(TAG, "BLE stack ready — starting BTHome advertising");
+    do_advertise();
+}
+
+static void on_reset(int reason)
+{
+    s_ble_ready = false;
+    ESP_LOGW(TAG, "BLE host reset (reason %d)", reason);
+}
+
+// NimBLE host task — runs nimble_port_run() which never returns normally
+static void ble_host_task(void *param)
+{
+    nimble_port_run();
+    nimble_port_freertos_deinit();
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void ble_bthome_init(void)
+{
+    esp_err_t ret = nimble_port_init();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "nimble_port_init failed: %s", esp_err_to_name(ret));
+        return;
+    }
+
+    ble_hs_cfg.sync_cb  = on_sync;
+    ble_hs_cfg.reset_cb = on_reset;
+
+    ble_svc_gap_init();
+    ble_svc_gap_device_name_set("AirCube");
+
+    nimble_port_freertos_init(ble_host_task);
+    ESP_LOGI(TAG, "BLE BTHome module initialized");
+}
+
+void ble_bthome_update(float temp_c, float humidity, int eco2, int etvoc)
+{
+    s_temp_x100 = (int16_t)(temp_c   * 100.0f);
+    s_hum_x100  = (uint16_t)(humidity * 100.0f);
+    s_co2  = (uint16_t)(eco2  < 65535 ? eco2  : 65535);
+    s_tvoc = (uint16_t)(etvoc < 65535 ? etvoc : 65535);
+
+    if (!s_ble_ready) {
+        return;
+    }
+
+    if (ble_gap_adv_active()) {
+        ble_gap_adv_stop();
+    }
+    do_advertise();
+}

--- a/firmware/main/ble_bthome.h
+++ b/firmware/main/ble_bthome.h
@@ -1,0 +1,42 @@
+/**
+ * @file ble_bthome.h
+ * @brief BLE BTHome v2 broadcaster for AirCube
+ *
+ * Advertises temperature, humidity, eCO2, and eTVOC in BTHome v2 format
+ * (service UUID 0xFCD2) so Home Assistant's Bluetooth integration
+ * auto-discovers the device through a nearby Bluetooth proxy.
+ *
+ * Non-connectable broadcast only — no pairing, no GATT server.
+ * Coexists with the Zigbee stack via ESP-IDF's software coexistence module.
+ */
+
+#ifndef BLE_BTHOME_H
+#define BLE_BTHOME_H
+
+#include <stdint.h>
+
+/**
+ * @brief Initialize the NimBLE stack and start BTHome advertising.
+ *
+ * Must be called after nvs_flash_init(). Starts advertising immediately
+ * once the BLE stack is synchronized (a few hundred milliseconds after
+ * this call returns). Safe to call alongside zigbee_init().
+ */
+void ble_bthome_init(void);
+
+/**
+ * @brief Update the advertised sensor values.
+ *
+ * Rebuilds the BTHome payload and restarts advertising with the new data.
+ * No-op until the BLE stack has completed initialization.
+ * Safe to call from any FreeRTOS task.
+ *
+ * @param temp_c   Temperature in °C (after offset correction)
+ * @param humidity Relative humidity in % (0-100)
+ * @param eco2     Equivalent CO2 in ppm
+ * @param etvoc    Equivalent TVOC in ppb (advertised in BTHome TVOC slot;
+ *                 HA labels the unit as µg/m³, values are ppb)
+ */
+void ble_bthome_update(float temp_c, float humidity, int eco2, int etvoc);
+
+#endif // BLE_BTHOME_H

--- a/firmware/main/ble_bthome.h
+++ b/firmware/main/ble_bthome.h
@@ -29,8 +29,6 @@ void ble_bthome_init(void);
  *
  * Rebuilds the BTHome payload and restarts advertising with the new data.
  * No-op until the BLE stack has completed initialization.
- * Safe to call from any FreeRTOS task.
- *
  * @param temp_c   Temperature in °C (after offset correction)
  * @param humidity Relative humidity in % (0-100)
  * @param eco2     Equivalent CO2 in ppm

--- a/firmware/main/led_color_lib.c
+++ b/firmware/main/led_color_lib.c
@@ -79,9 +79,8 @@ uint32_t get_color_from_hue(uint16_t hue) {
 uint32_t get_next_color_full_spectrum(void) {
     uint32_t color = get_color_from_hue(current_hue);
 
-    // Increment hue for next call
+    // Increment hue for next call — uint16_t wraps at 65536 automatically
     current_hue += hue_increment;
-    if (current_hue >= 65536) current_hue = 0;  // Wrap around
 
     return color;
 }

--- a/firmware/main/main.c
+++ b/firmware/main/main.c
@@ -15,6 +15,7 @@
 #include "button.h"
 #include "history.h"
 #include "zigbee.h"
+#include "ble_bthome.h"
 
 static const char *TAG = "main";
 
@@ -444,12 +445,13 @@ void sensor_task(void *pvParameters)
         history_record_sample(temp_c, humidity, aqi, eco2, etvoc);
         history_check_flush();
         
-        // Push sensor data to Zigbee attributes every 10 seconds
+        // Push sensor data to Zigbee and BLE every 10 seconds
         static TickType_t last_zb_update = 0;
         TickType_t now = xTaskGetTickCount();
         if ((now - last_zb_update) >= pdMS_TO_TICKS(10000)) {
             last_zb_update = now;
             zigbee_update_sensors(temp_c, humidity, eco2, etvoc, aqi);
+            ble_bthome_update(temp_c, humidity, eco2, etvoc);
         }
 
         // Wait for configurable period before next reading
@@ -546,6 +548,9 @@ void app_main(void)
     
     // Initialize Zigbee stack (End Device, idles until long-press on first boot)
     zigbee_init();
+
+    // Initialize BLE BTHome broadcaster (shares radio with Zigbee via coexistence)
+    ble_bthome_init();
     
     // Create command processing task
     xTaskCreate(command_task, "command_task", COMMAND_TASK_STACK_SIZE, NULL, 

--- a/firmware/sdkconfig.defaults
+++ b/firmware/sdkconfig.defaults
@@ -25,3 +25,22 @@ CONFIG_ZB_ZED=y
 CONFIG_ZB_RADIO_NATIVE=y
 # CONFIG_ZB_RADIO_SPINEL_UART is not set
 CONFIG_AIRCUBE_ZB_TX_POWER_DBM=20
+
+#
+# Bluetooth — NimBLE broadcaster for BTHome v2 (firmware/main/ble_bthome.c)
+#
+CONFIG_BT_ENABLED=y
+CONFIG_BT_NIMBLE_ENABLED=y
+# Non-connectable broadcast only; disable unused roles to save flash/RAM
+CONFIG_BT_NIMBLE_ROLE_CENTRAL=n
+CONFIG_BT_NIMBLE_ROLE_OBSERVER=n
+CONFIG_BT_NIMBLE_ROLE_PERIPHERAL=n
+CONFIG_BT_NIMBLE_ROLE_BROADCASTER=y
+# Maximum advertising instances (1 is enough for BTHome)
+CONFIG_BT_NIMBLE_MAX_EXT_ADV_INSTANCES=0
+
+#
+# Radio coexistence — Zigbee (802.15.4) + BLE share the 2.4 GHz radio.
+# Without this the two stacks will conflict.
+#
+CONFIG_ESP_COEX_SW_COEXIST_ENABLE=y

--- a/firmware/sdkconfig.defaults
+++ b/firmware/sdkconfig.defaults
@@ -3,10 +3,10 @@
 #
 
 #
-# Flash size (AirCube uses 4MB GD flash)
+# Flash size (AirCube hardware has 2MB flash)
 #
-CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
-CONFIG_ESPTOOLPY_FLASHSIZE="4MB"
+CONFIG_ESPTOOLPY_FLASHSIZE_2MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="2MB"
 
 #
 # Custom partition table (includes zb_storage, zb_fct, and history partitions)

--- a/firmware/sdkconfig.defaults
+++ b/firmware/sdkconfig.defaults
@@ -32,11 +32,11 @@ CONFIG_AIRCUBE_ZB_TX_POWER_DBM=20
 CONFIG_BT_ENABLED=y
 CONFIG_BT_NIMBLE_ENABLED=y
 # Non-connectable broadcast only; disable unused roles to save flash/RAM
-CONFIG_BT_NIMBLE_ROLE_CENTRAL=n
-CONFIG_BT_NIMBLE_ROLE_OBSERVER=n
-CONFIG_BT_NIMBLE_ROLE_PERIPHERAL=n
+# CONFIG_BT_NIMBLE_ROLE_CENTRAL is not set
+# CONFIG_BT_NIMBLE_ROLE_OBSERVER is not set
+# CONFIG_BT_NIMBLE_ROLE_PERIPHERAL is not set
 CONFIG_BT_NIMBLE_ROLE_BROADCASTER=y
-# Maximum advertising instances (1 is enough for BTHome)
+# Disable extended advertising controller; legacy advertising is used instead
 CONFIG_BT_NIMBLE_MAX_EXT_ADV_INSTANCES=0
 
 #


### PR DESCRIPTION
## What this does

Adds a non-connectable BLE broadcaster (`ble_bthome.c/h`) that advertises
the AirCube's four sensor readings in BTHome v2 format. Home Assistant's
Bluetooth integration auto-discovers the device through any nearby
Bluetooth proxy — no custom ZHA quirk or Zigbee2MQTT converter required
for the HA side.

Sensors advertised:
- Temperature (°C)
- Relative humidity (%)
- eCO2 (ppm)
- eTVOC (ppb, in the BTHome TVOC slot; HA labels the unit as µg/m³)

The BLE stack runs alongside Zigbee using ESP-IDF's software coexistence
module (`CONFIG_ESP_COEX_SW_COEXIST_ENABLE`). Both transports remain
active simultaneously.

Advertising interval is 500–1000 ms at startup, then refreshed every
10 seconds when the sensor task pushes a new reading — the same cadence
as the existing Zigbee attribute reports.

BTHome v2 spec: https://bthome.io/format/

## Also fixed in this branch

**Flash size declaration (sdkconfig.defaults):** The defaults file declared
4 MB flash but the AirCube hardware has a 2 MB chip. This caused the
bootloader to abort on every boot with:

`Detected size(2048k) smaller than the size in the binary image header(4096k)`

The partition table already targeted 2 MB (its header comment said so);
only the flash size declaration was wrong.

**Pre-existing compiler error (led_color_lib.c):** ESP-IDF 6.x enables
`-Werror=type-limits` under `-std=gnu23`. A dead comparison
`if (current_hue >= 65536)` where `current_hue` is `uint16_t` was always
false and triggered this error. Removed the check; `uint16_t` wraps at
65536 automatically.

## Implementation notes

`ble_bthome_update()` calls NimBLE GAP functions (`ble_gap_adv_stop`,
`ble_gap_adv_start`) from the sensor task rather than posting to the NimBLE
event queue. This works reliably on the single-core ESP32-H2 because the
ESP-IDF NimBLE port serializes HCI calls through a thread-safe layer, but
it is not strictly per the NimBLE design. Happy to convert to a
`ble_npl_callout`-based approach if preferred.

## Tested on hardware

Verified on an AirCube (ESP32-H2 rev 1.2, 2 MB flash) with an ESPHome
Bluetooth proxy forwarding advertisements to Home Assistant. All four
sensors appeared in HA under the BTHome integration immediately after boot
with no manual configuration.