### PR TITLE
Add browser-based AirCube monitor (Web Serial) for Chromebooks

### DIFF
--- a/scripts/WEBAPP_README.md
+++ b/scripts/WEBAPP_README.md
@@ -1,0 +1,197 @@
+# AirCube Web Serial Monitor
+
+`aircube_webapp.html` is a browser-based replacement for the `aircube_app.py`
+desktop app. It reads the AirCube's live sensor stream over the **Web Serial
+API** and shows current values, scrolling charts, CSV logging, and device
+controls -- all from a single self-contained HTML file (no build step, no
+external libraries, works offline).
+
+It exists because the Python desktop app **cannot run on a Chromebook**. The
+sections below explain why, and document the one non-obvious detail (the DTR/RTS
+handshake) that makes reading work.
+
+---
+
+## Quick start
+
+1. **Un-share the device from Linux.** In ChromeOS Settings -> About ChromeOS ->
+   Linux -> USB preferences, make sure **"USB JTAG/serial debug unit"** is
+   **OFF** (not shared into Crostini). Web Serial reads through the ChromeOS host
+   driver, so the device must stay with the host.
+2. **Serve the page over a secure context.** Web Serial only works over `https`
+   or `http://localhost`. The simplest local option:
+   ```bash
+   cd scripts
+   python3 -m http.server 8000
+   ```
+   If `http://localhost:8000` is not reachable from the ChromeOS browser, add a
+   port-forward for TCP 8000 in ChromeOS Settings -> About ChromeOS -> Linux ->
+   Port forwarding.
+3. **Open it in Chrome** (or Edge): `http://localhost:8000/aircube_webapp.html`
+4. Click **Connect**, choose the AirCube in the picker, and live data appears.
+
+Opening the file directly with a `file://` URL will **not** work -- that is not a
+secure context and Web Serial is disabled there.
+
+---
+
+## Features
+
+Faithful to `aircube_app.py`:
+
+- **Live value cards**: Temperature, Humidity, AQI, eCO2, eTVOC. AQI is color
+  coded with the same bands as the desktop app and the device LED gradient:
+  green (<=50), yellow (<=100), orange (<=200), red (>200).
+- **Three scrolling charts** (canvas, no external chart library):
+  Temperature + Humidity, AQI, and eCO2 + eTVOC, with the x-axis in seconds
+  since the first sample.
+- **History window** control (default 300 points) limits how much the charts
+  show.
+- **CSV logging** with the identical 9-column header
+  (`timestamp, ens210_status, temperature_c, temperature_f, humidity,
+  ens16x_status, etvoc, eco2, aqi`):
+  - **Download CSV (session)** exports everything captured since connecting.
+  - **Start file log...** streams each sample to a chosen file via Chrome's
+    File System Access API (data is committed when you Stop the log).
+- **Sample count** and **connection status** in the header.
+
+Added on top of the desktop app (these use firmware commands the Python app
+never exposed):
+
+- **Temperature unit toggle** (C / F) -- updates the card and the chart live.
+- **Field definition tooltips** -- hover any value label for a plain-language
+  definition.
+- **Device controls**:
+  - **Get config** -> reads current LED intensity and readout period.
+  - **LED intensity** slider -> `set_intensity` (0.0 - 1.0).
+  - **Readout period** -> `set_readout_period` (100 - 10000 ms).
+  - **Request history dump (h)** -> dumps stored history as CSV into the log.
+
+---
+
+## Why the Python app does not work on a Chromebook
+
+This took a full debugging session to pin down. The findings, in order:
+
+The AirCube is an **ESP32-H2** using the chip's **native USB Serial/JTAG**
+peripheral (USB id **`0x303A:0x1001`**). It enumerates as a *vendor-specific*
+(class `0xFF`) device with three interfaces:
+
+| Interface | Endpoints           | Purpose                          |
+|-----------|---------------------|----------------------------------|
+| 0         | interrupt IN `0x82` | CDC comm / control               |
+| 1         | bulk OUT `0x01`, IN `0x81` | serial console stream (the JSON) |
+| 2         | bulk OUT/IN         | JTAG                             |
+
+What we tried, and what happened:
+
+1. **pyserial (what `aircube_app.py` uses) sees nothing.** The Crostini
+   (termina) VM kernel has **no `cdc-acm` module** (`modprobe cdc-acm` fails),
+   so no `/dev/ttyACM*` node is ever created. `serial.tools.list_ports.comports()`
+   returns an empty list. (Reproduce with `test_serial_discovery.py`.)
+
+2. **pyusb in Crostini can open the device but cannot read.** It discovers and
+   opens `0x303A:0x1001` and finds endpoint `0x81`, but the device gates its TX
+   until the host marks the port "connected", and the required control transfer
+   (`SET_CONTROL_LINE_STATE`, a class interface-OUT request) **times out** through
+   ChromeOS/Crostini's USB passthrough. Class-IN requests (`GET_LINE_CODING`) and
+   standard control-OUT (`set_configuration`) work -- only class control-OUT is
+   dropped. (Reproduce with `test_pyusb_discovery.py`.)
+
+3. **WebUSB in the browser cannot claim the interface.** The ChromeOS *host*
+   kernel's `cdc-acm` driver owns the interface (`claimInterface` fails with
+   "Unable to claim interface"). That failure is the clue that the host exposes
+   the device as a serial port.
+
+4. **Web Serial works** -- it reads *through* the host `cdc-acm` driver instead
+   of fighting it, and it can assert DTR/RTS natively via `setSignals()`.
+
+### The key detail: DTR = 0, RTS = 1
+
+The ESP32-H2 USB Serial/JTAG only streams once the host marks the port
+"connected". The combination that works is:
+
+```js
+port.setSignals({ dataTerminalReady: false, requestToSend: true });  // DTR=0, RTS=1
+```
+
+Setting **DTR = 1 resets/halts** the chip (the USB Serial/JTAG ROM interprets
+certain DTR/RTS states as a reset-into-download-mode request), which produces
+total silence. This was the root cause of a long "why is there no data" hunt:
+every earlier attempt asserted DTR=1 and got nothing. The desktop app works on a
+normal laptop only because the laptop's `cdc-acm` driver handles this for it.
+
+The firmware streams sensor JSON unconditionally about once per second
+(`serial_send_sensor_data` in `firmware/main/serial_protocol.c`), so once the
+signal handshake is right, data flows immediately.
+
+---
+
+## Serial protocol reference
+
+**Sensor stream** (one newline-terminated JSON object per readout period):
+
+```json
+{"ens210":{"status":0,"temperature_c":22.50,"temperature_f":72.50,"humidity":45.00},
+ "ens16x":{"status":"OK","etvoc":120,"eco2":650,"aqi":95,"aqi_s":100,"aqi_uba":2},
+ "timestamp":123456}
+```
+`timestamp` is milliseconds since boot. `aqi` is the canonical TVOC-derived AQI
+(0-500). `aqi_s` (ScioSense relative score) and `aqi_uba` are USB-serial only.
+
+**Commands** (send as a newline-terminated line):
+
+| Command | Effect | Response |
+|---------|--------|----------|
+| `{"cmd":"get_config"}` | read settings | `{"config":{"intensity":f,"readout_period":ms}}` |
+| `{"cmd":"set_intensity","value":0.0-1.0}` | LED brightness | `{"status":"ok","cmd":"set_intensity","value":f}` |
+| `{"cmd":"set_readout_period","value":100-10000}` | sample period (ms) | `{"status":"ok",...}` |
+| `{"cmd":"get_history_info"}` | history metadata | `{"history_info":{...}}` |
+| `{"cmd":"get_history","start":n,"count":n}` | history page | history rows |
+| `{"cmd":"clear_history"}` | erase stored history | status |
+| `h` | dump full history as CSV | CSV text |
+
+---
+
+## Browser requirements
+
+- **Chrome or Edge** (Web Serial is not in Firefox or Safari).
+- A **secure context**: `https://` or `http://localhost`.
+- **File System Access API** (Chrome/Edge) is needed for "Start file log...";
+  "Download CSV" works everywhere Web Serial does.
+
+---
+
+## Troubleshooting
+
+- **Device not in the Connect picker** -> it is still shared into Linux (Crostini)
+  or held by another tab/app. Un-share it (Quick start step 1) and close other
+  connections.
+- **Connects but no data / byte counter stays at 0** -> the signal handshake is
+  wrong for your situation. The app uses DTR=0 RTS=1; if you forked it, do not
+  assert DTR=1 (it resets the chip). The standalone `webserial_aircube_test.html`
+  has manual signal buttons for experimenting.
+- **"Web Serial unavailable"** -> you opened the file over `file://` or plain
+  `http`. Serve it over `localhost` or `https`.
+- **Garbled characters** -> unrelated terminal/font issue; does not affect the
+  web app.
+
+---
+
+## Files in this folder
+
+| File | Purpose |
+|------|---------|
+| `aircube_webapp.html` | The full web app (this README documents it). |
+| `webserial_aircube_test.html` | Minimal Web Serial signal tester (DTR/RTS buttons, byte counter). |
+| `webusb_aircube_test.html` | Minimal WebUSB probe (shows why WebUSB cannot claim the interface). |
+| `test_serial_discovery.py` | Proves pyserial sees no ports in Crostini. |
+| `test_pyusb_discovery.py` | Proves pyusb can open but not read (DTR control-OUT times out). |
+| `aircube_app.py` | Original PyQt6 desktop app (works on a regular laptop, not a Chromebook). |
+
+---
+
+## License
+
+Apache License 2.0. See the repository `LICENSE` file. The web app carries the
+standard Apache 2.0 header at the top of `aircube_webapp.html`.

--- a/scripts/aircube_webapp.html
+++ b/scripts/aircube_webapp.html
@@ -1,0 +1,454 @@
+<!DOCTYPE html>
+<!--
+  AirCube Web Serial Monitor
+  Copyright 2026 The AirCube Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>AirCube - Air Quality Monitor (Web Serial)</title>
+<style>
+  :root { --green:#2e7d32; --yellow:#f9a825; --orange:#ef6c00; --red:#c62828; }
+  * { box-sizing: border-box; }
+  body { font-family: system-ui, "Segoe UI", sans-serif; margin: 0; background: #f5f5f5; color: #222; }
+  header { background: #263238; color: #fff; padding: 0.7rem 1rem; display: flex;
+           align-items: center; gap: 1rem; flex-wrap: wrap; }
+  header h1 { font-size: 1.1rem; margin: 0; font-weight: 600; }
+  .grow { flex: 1; }
+  button { font-size: 0.9rem; padding: 0.45rem 0.9rem; border: none; border-radius: 4px;
+           cursor: pointer; background: #455a64; color: #fff; }
+  button:hover { background: #37474f; }
+  button.primary { background: #4CAF50; }
+  button.primary:hover { background: #45a049; }
+  button.danger { background: #f44336; }
+  button.danger:hover { background: #da190b; }
+  button:disabled { background: #b0bec5; cursor: default; }
+  .status { font-weight: 600; }
+  main { padding: 1rem; max-width: 1100px; margin: 0 auto; }
+  .panel { background: #fff; border: 1px solid #ddd; border-radius: 6px; padding: 1rem;
+           margin-bottom: 1rem; }
+  .panel h2 { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.04em;
+              color: #607d8b; margin: 0 0 0.7rem; }
+  .cards { display: flex; gap: 1rem; flex-wrap: wrap; }
+  .card { flex: 1; min-width: 120px; text-align: center; background: #fafafa;
+          border: 1px solid #eee; border-radius: 6px; padding: 0.8rem 0.5rem; }
+  .card .title { font-size: 0.75rem; color: #666; }
+  .card .title[data-tip] { cursor: help; border-bottom: 1px dotted #aaa; }
+  #tip { position: fixed; z-index: 1000; max-width: 280px; background: #333; color: #fff;
+         padding: 0.5rem 0.6rem; border-radius: 5px; font-size: 0.78rem; line-height: 1.35;
+         white-space: normal; box-shadow: 0 2px 10px rgba(0,0,0,.35); display: none;
+         pointer-events: none; }
+  .card .val { font-size: 2rem; font-weight: 700; line-height: 1.1; }
+  .card .unit { font-size: 0.8rem; color: #888; }
+  canvas.chart { width: 100%; height: 170px; display: block; }
+  .row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; margin: 0.4rem 0; }
+  label { font-size: 0.85rem; }
+  input[type=number] { width: 90px; padding: 0.3rem; border: 1px solid #ccc; border-radius: 4px; }
+  input[type=range] { vertical-align: middle; }
+  #log { white-space: pre-wrap; background: #111; color: #9ccc65; padding: 0.7rem;
+         border-radius: 6px; height: 160px; overflow-y: auto; font-family: ui-monospace, monospace;
+         font-size: 0.78rem; }
+  .muted { color: #888; font-size: 0.8rem; }
+  details summary { cursor: pointer; font-size: 0.85rem; color: #607d8b; }
+</style>
+</head>
+<body>
+<header>
+  <h1>AirCube</h1>
+  <button id="connectBtn" class="primary">Connect</button>
+  <span id="connStatus" class="status" style="color:#ff8a80">Disconnected</span>
+  <span class="grow"></span>
+  <button id="unitBtn">Units: C</button>
+  <span id="sampleStatus" class="muted">Samples: 0</span>
+  <label class="muted">History
+    <input type="number" id="maxPoints" value="300" min="50" max="2000" step="50" style="width:70px">
+    pts</label>
+</header>
+
+<div id="tip"></div>
+<main>
+  <div class="panel">
+    <div class="cards">
+      <div class="card"><div class="title" data-tip="Ambient air temperature measured by the ENS210 sensor. Toggle the Units button to switch between Celsius and Fahrenheit.">Temperature</div><div class="val" id="cTemp">--.-</div><div class="unit" id="cTempUnit">&deg;C</div></div>
+      <div class="card"><div class="title" data-tip="Relative humidity (%) from the ENS210 sensor: how much water vapor is in the air versus the maximum it could hold at this temperature. Comfortable indoor range is roughly 30-60%.">Humidity</div><div class="val" id="cHum">--.-</div><div class="unit">%</div></div>
+      <div class="card"><div class="title" data-tip="Air Quality Index (0-500): TVOC mapped to a fixed indoor-air scale. Lower is better -- green (good) up to ~50, yellow up to ~100, orange up to ~200, red above. Derived from eTVOC; eCO2 does not affect it.">Air Quality Index</div><div class="val" id="cAqi">---</div><div class="unit">AQI</div></div>
+      <div class="card"><div class="title" data-tip="Equivalent CO2: an estimated CO2 concentration (ppm) derived by the sensor from VOC readings -- not a direct CO2 measurement. Rises in poorly ventilated or crowded spaces. ~400 ppm is fresh outdoor air; above ~1000 ppm suggests ventilation is needed.">eCO2</div><div class="val" id="cEco2">----</div><div class="unit">ppm</div></div>
+      <div class="card"><div class="title" data-tip="Equivalent Total Volatile Organic Compounds: estimated total airborne VOC concentration (ppb) from sources like cleaning products, paints, adhesives, furnishings, cooking, and people. Higher values mean more VOCs; ventilate to reduce.">eTVOC</div><div class="val" id="cTvoc">----</div><div class="unit">ppb</div></div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2>Sensor history</h2>
+    <canvas class="chart" id="chartTH"></canvas>
+    <canvas class="chart" id="chartAQI"></canvas>
+    <canvas class="chart" id="chartGas"></canvas>
+  </div>
+
+  <div class="panel">
+    <h2>CSV logging</h2>
+    <div class="row">
+      <button id="logFileBtn">Start file log...</button>
+      <button id="downloadBtn">Download CSV (session)</button>
+      <span id="csvStatus" class="muted"></span>
+    </div>
+    <div class="muted">File log streams each sample to a chosen file (committed when you Stop).
+      Download exports everything captured this session.</div>
+  </div>
+
+  <div class="panel">
+    <h2>Device controls</h2>
+    <div class="row">
+      <button id="getConfigBtn">Get config</button>
+      <span id="cfgStatus" class="muted"></span>
+    </div>
+    <div class="row">
+      <label>LED intensity</label>
+      <input type="range" id="intensity" min="0" max="1" step="0.01" value="0.5">
+      <span id="intensityVal" class="muted">0.50</span>
+      <button id="setIntensityBtn">Set</button>
+    </div>
+    <div class="row">
+      <label>Readout period</label>
+      <input type="number" id="period" min="100" max="10000" step="100" value="1000"> ms
+      <button id="setPeriodBtn">Set</button>
+    </div>
+    <div class="row">
+      <button id="historyBtn">Request history dump (h)</button>
+    </div>
+  </div>
+
+  <div class="panel">
+    <details open>
+      <summary>Serial log</summary>
+      <div id="log" style="margin-top:0.5rem"></div>
+    </details>
+  </div>
+</main>
+
+<script>
+"use strict";
+const VID = 0x303A;
+const CSV_HEADER = ["timestamp","ens210_status","temperature_c","temperature_f",
+  "humidity","ens16x_status","etvoc","eco2","aqi"];
+
+// ---- state ----
+let port = null, reading = false, rxBuf = "";
+let activeReader = null, readDone = null;
+let t0 = null, sampleCount = 0;
+let buffer = [];            // chart window: {t,temp,hum,aqi,eco2,etvoc}
+let csvRows = [];           // full session rows for download
+let maxPoints = 300;
+let csvWritable = null;     // File System Access writable stream
+let tempUnit = "C";         // "C" or "F" for display
+let lastVals = null;        // last sample, for redrawing cards on unit toggle
+
+const $ = id => document.getElementById(id);
+const logEl = $("log");
+function log(m) { logEl.textContent += m + "\n"; logEl.scrollTop = logEl.scrollHeight; }
+
+// ---- connection ----
+$("connectBtn").addEventListener("click", () => port ? disconnect() : connect());
+
+navigator.serial?.addEventListener("disconnect", () => {
+  if (port) { log("*** device disconnected ***"); disconnect(); }
+});
+
+async function connect() {
+  if (!("serial" in navigator)) {
+    alert("Web Serial unavailable. Use Chrome over https or http://localhost.");
+    return;
+  }
+  try { port = await navigator.serial.requestPort({ filters: [{ usbVendorId: VID }] }); }
+  catch (e) { log("no port selected: " + e); port = null; return; }
+  try { await port.open({ baudRate: 115200 }); }
+  catch (e) { log("open failed: " + e); port = null; return; }
+
+  // The handshake the ESP32-H2 USB Serial/JTAG needs: DTR low, RTS high.
+  try { await port.setSignals({ dataTerminalReady: false, requestToSend: true }); }
+  catch (e) { log("setSignals failed: " + e); }
+
+  t0 = null; sampleCount = 0; buffer = []; csvRows = []; rxBuf = "";
+  setConnectedUI(true);
+  reading = true;
+  log("connected (DTR=0 RTS=1)");
+  readDone = readLoop();
+}
+
+async function disconnect() {
+  reading = false;
+  // Cancel the reader so read() resolves and the loop releases its lock,
+  // then wait for the loop to finish before closing the port.
+  if (activeReader) { try { await activeReader.cancel(); } catch (e) {} }
+  if (readDone) { try { await readDone; } catch (e) {} readDone = null; }
+  try { await stopFileLog(); } catch (e) {}
+  if (port) {
+    try { await port.close(); } catch (e) { log("close: " + e); }
+    port = null;
+  }
+  setConnectedUI(false);
+  log("disconnected");
+}
+
+function setConnectedUI(on) {
+  $("connectBtn").textContent = on ? "Disconnect" : "Connect";
+  $("connectBtn").className = on ? "danger" : "primary";
+  $("connStatus").textContent = on ? "Connected" : "Disconnected";
+  $("connStatus").style.color = on ? "#b9f6ca" : "#ff8a80";
+}
+
+async function readLoop() {
+  const dec = new TextDecoder();
+  try { activeReader = port.readable.getReader(); } catch (e) { log("getReader: " + e); return; }
+  try {
+    while (reading) {
+      const { value, done } = await activeReader.read();
+      if (done) break;
+      if (value && value.length) {
+        rxBuf += dec.decode(value);
+        let nl;
+        while ((nl = rxBuf.indexOf("\n")) >= 0) {
+          const line = rxBuf.slice(0, nl).trim();
+          rxBuf = rxBuf.slice(nl + 1);
+          if (line) handleLine(line);
+        }
+      }
+    }
+  } catch (e) { if (reading) log("read error: " + e); }
+  finally { try { activeReader.releaseLock(); } catch (e) {} activeReader = null; }
+}
+
+// ---- writing commands ----
+async function sendCommand(str) {
+  if (!port || !port.writable) { log("not connected"); return; }
+  const writer = port.writable.getWriter();
+  try { await writer.write(new TextEncoder().encode(str + "\n")); log("TX: " + str); }
+  catch (e) { log("write error: " + e); }
+  finally { writer.releaseLock(); }
+}
+
+// ---- line handling ----
+function handleLine(line) {
+  let j = null;
+  try { j = JSON.parse(line); } catch (e) {}
+  if (j && j.ens210 && j.ens16x) { onSensor(j); return; }
+  if (j && j.config) {
+    $("cfgStatus").textContent = `intensity ${j.config.intensity}, period ${j.config.readout_period} ms`;
+    if (typeof j.config.intensity === "number") {
+      $("intensity").value = j.config.intensity;
+      $("intensityVal").textContent = (+j.config.intensity).toFixed(2);
+    }
+    if (typeof j.config.readout_period === "number") $("period").value = j.config.readout_period;
+    log("RX config: " + line);
+    return;
+  }
+  // status responses, history info, history CSV dump, or ESP_LOG lines
+  log("RX: " + line);
+}
+
+function onSensor(j) {
+  const ts = Number(j.timestamp);
+  if (!Number.isFinite(ts)) return;
+  if (t0 === null) t0 = ts;
+  const tRel = ts > 1000 ? (ts - t0) / 1000 : (ts - t0);   // firmware sends ms
+
+  const tempC = num(j.ens210.temperature_c);
+  let   tempF = num(j.ens210.temperature_f);
+  const hum   = num(j.ens210.humidity);
+  const aqi   = num(j.ens16x.aqi);
+  const eco2  = num(j.ens16x.eco2);
+  const etvoc = num(j.ens16x.etvoc);
+  if (tempC === null || hum === null || aqi === null) return;
+  if (tempF === null) tempF = tempC * 9 / 5 + 32;   // fallback if firmware omits it
+
+  buffer.push({ t: tRel, temp: tempC, tempF, hum, aqi, eco2: eco2 ?? NaN, etvoc: etvoc ?? NaN });
+  if (buffer.length > maxPoints) buffer.splice(0, buffer.length - maxPoints);
+
+  sampleCount++;
+  $("sampleStatus").textContent = "Samples: " + sampleCount;
+  lastVals = { tempC, tempF, hum, aqi, eco2, etvoc };
+  updateCards();
+
+  const row = [j.timestamp, j.ens210.status, j.ens210.temperature_c, j.ens210.temperature_f,
+    j.ens210.humidity, j.ens16x.status, j.ens16x.etvoc, j.ens16x.eco2, j.ens16x.aqi];
+  csvRows.push(row);
+  if (csvWritable) csvWritable.write(row.join(",") + "\n").catch(e => log("csv write: " + e));
+}
+
+const num = v => (v === null || v === undefined || isNaN(v)) ? null : Number(v);
+
+function updateCards() {
+  if (!lastVals) return;
+  const { tempC, tempF, hum, aqi, eco2, etvoc } = lastVals;
+  $("cTemp").textContent = (tempUnit === "F" ? tempF : tempC).toFixed(1);
+  $("cTempUnit").innerHTML = tempUnit === "F" ? "&deg;F" : "&deg;C";
+  $("cHum").textContent  = hum.toFixed(1);
+  const aqiEl = $("cAqi");
+  aqiEl.textContent = Math.round(aqi);
+  aqiEl.style.color = aqi <= 50 ? "var(--green)" : aqi <= 100 ? "var(--yellow)"
+                    : aqi <= 200 ? "var(--orange)" : "var(--red)";
+  if (eco2 !== null) $("cEco2").textContent = Math.round(eco2);
+  if (etvoc !== null) $("cTvoc").textContent = Math.round(etvoc);
+}
+
+// ---- charts (dependency-free canvas) ----
+function drawChart(canvas, xs, series) {
+  const ctx = canvas.getContext("2d");
+  const dpr = window.devicePixelRatio || 1;
+  const w = canvas.clientWidth, h = canvas.clientHeight;
+  if (canvas.width !== w * dpr || canvas.height !== h * dpr) { canvas.width = w * dpr; canvas.height = h * dpr; }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, w, h);
+  const padL = 52, padR = 10, padT = 8, padB = 20;
+  const pw = w - padL - padR, ph = h - padT - padB;
+  if (!xs.length) return;
+  let xmin = xs[0], xmax = xs[xs.length - 1]; if (xmax === xmin) xmax = xmin + 1;
+  let ymin = Infinity, ymax = -Infinity;
+  for (const s of series) for (const v of s.data) if (v != null && !isNaN(v)) { if (v < ymin) ymin = v; if (v > ymax) ymax = v; }
+  if (!isFinite(ymin)) { ymin = 0; ymax = 1; }
+  if (ymin === ymax) { ymin -= 1; ymax += 1; }
+  const yr = ymax - ymin; ymin -= yr * 0.08; ymax += yr * 0.08;
+  const X = x => padL + (x - xmin) / (xmax - xmin) * pw;
+  const Y = y => padT + (1 - (y - ymin) / (ymax - ymin)) * ph;
+
+  ctx.strokeStyle = "#e8e8e8"; ctx.fillStyle = "#888"; ctx.lineWidth = 1; ctx.font = "10px sans-serif";
+  for (let i = 0; i <= 4; i++) {
+    const yv = ymin + (ymax - ymin) * i / 4, py = Y(yv);
+    ctx.beginPath(); ctx.moveTo(padL, py); ctx.lineTo(w - padR, py); ctx.stroke();
+    ctx.textAlign = "right"; ctx.fillText(yv.toFixed(1), padL - 4, py + 3);
+  }
+  ctx.textAlign = "center";
+  for (let i = 0; i <= 5; i++) {
+    const xv = xmin + (xmax - xmin) * i / 5;
+    ctx.fillText(xv.toFixed(0) + "s", X(xv), h - 6);
+  }
+  for (const s of series) {
+    ctx.strokeStyle = s.color; ctx.lineWidth = 1.5; ctx.beginPath();
+    let started = false;
+    for (let i = 0; i < xs.length; i++) {
+      const v = s.data[i];
+      if (v == null || isNaN(v)) { started = false; continue; }
+      const px = X(xs[i]), py = Y(v);
+      if (!started) { ctx.moveTo(px, py); started = true; } else ctx.lineTo(px, py);
+    }
+    ctx.stroke();
+  }
+  let lx = padL + 2; const ly = padT + 10;
+  ctx.textAlign = "left";
+  for (const s of series) {
+    ctx.fillStyle = s.color; ctx.fillRect(lx, ly - 8, 10, 10);
+    ctx.fillStyle = "#444"; ctx.fillText(s.label, lx + 13, ly);
+    lx += 13 + ctx.measureText(s.label).width + 14;
+  }
+}
+
+function redraw() {
+  if (!buffer.length) return;
+  const xs = buffer.map(p => p.t);
+  drawChart($("chartTH"), xs, [
+    { label: "Temp (" + tempUnit + ")", color: "#e53935",
+      data: buffer.map(p => tempUnit === "F" ? p.tempF : p.temp) },
+    { label: "Humidity (%)", color: "#1e88e5", data: buffer.map(p => p.hum) },
+  ]);
+  drawChart($("chartAQI"), xs, [
+    { label: "AQI", color: "#7cb342", data: buffer.map(p => p.aqi) },
+  ]);
+  drawChart($("chartGas"), xs, [
+    { label: "eCO2 (ppm)", color: "#8e24aa", data: buffer.map(p => p.eco2) },
+    { label: "eTVOC (ppb)", color: "#00897b", data: buffer.map(p => p.etvoc) },
+  ]);
+}
+setInterval(redraw, 500);
+window.addEventListener("resize", redraw);
+
+// ---- field definition tooltips (wrap + clamp to viewport so nothing clips) ----
+const tipEl = $("tip");
+document.querySelectorAll(".card .title[data-tip]").forEach(el => {
+  const show = () => {
+    tipEl.textContent = el.dataset.tip;
+    tipEl.style.display = "block";
+    const r = el.getBoundingClientRect();
+    let left = r.left + r.width / 2 - tipEl.offsetWidth / 2;
+    left = Math.max(8, Math.min(left, window.innerWidth - tipEl.offsetWidth - 8));
+    let top = r.bottom + 6;
+    if (top + tipEl.offsetHeight > window.innerHeight - 8) top = r.top - tipEl.offsetHeight - 6;
+    tipEl.style.left = left + "px";
+    tipEl.style.top = Math.max(8, top) + "px";
+  };
+  const hide = () => { tipEl.style.display = "none"; };
+  el.addEventListener("mouseenter", show);
+  el.addEventListener("mouseleave", hide);
+});
+
+// ---- temperature unit toggle ----
+$("unitBtn").addEventListener("click", () => {
+  tempUnit = tempUnit === "C" ? "F" : "C";
+  $("unitBtn").textContent = "Units: " + tempUnit;
+  updateCards();
+  redraw();
+});
+
+// ---- history points ----
+$("maxPoints").addEventListener("change", e => {
+  maxPoints = Math.max(50, Math.min(2000, parseInt(e.target.value) || 300));
+  if (buffer.length > maxPoints) buffer.splice(0, buffer.length - maxPoints);
+});
+
+// ---- CSV ----
+$("downloadBtn").addEventListener("click", () => {
+  const text = CSV_HEADER.join(",") + "\n" + csvRows.map(r => r.join(",")).join("\n") + "\n";
+  const blob = new Blob([text], { type: "text/csv" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = "aircube_log_" + new Date().toISOString().replace(/[:.]/g, "-") + ".csv";
+  a.click();
+  URL.revokeObjectURL(a.href);
+});
+
+$("logFileBtn").addEventListener("click", async () => {
+  if (csvWritable) { await stopFileLog(); return; }
+  if (!window.showSaveFilePicker) { alert("File logging needs Chrome's File System Access API. Use Download CSV instead."); return; }
+  try {
+    const handle = await window.showSaveFilePicker({
+      suggestedName: "aircube_log_" + new Date().toISOString().replace(/[:.]/g, "-") + ".csv",
+      types: [{ description: "CSV", accept: { "text/csv": [".csv"] } }],
+    });
+    csvWritable = await handle.createWritable();
+    await csvWritable.write(CSV_HEADER.join(",") + "\n");
+    $("logFileBtn").textContent = "Stop file log";
+    $("csvStatus").textContent = "logging to " + handle.name;
+  } catch (e) { log("file log: " + e); }
+});
+
+async function stopFileLog() {
+  if (csvWritable) { try { await csvWritable.close(); } catch (e) {} csvWritable = null; }
+  $("logFileBtn").textContent = "Start file log...";
+  $("csvStatus").textContent = "";
+}
+
+// ---- device controls ----
+$("getConfigBtn").addEventListener("click", () => sendCommand('{"cmd":"get_config"}'));
+$("intensity").addEventListener("input", e => $("intensityVal").textContent = (+e.target.value).toFixed(2));
+$("setIntensityBtn").addEventListener("click", () =>
+  sendCommand('{"cmd":"set_intensity","value":' + (+$("intensity").value) + "}"));
+$("setPeriodBtn").addEventListener("click", () => {
+  let p = Math.max(100, Math.min(10000, parseInt($("period").value) || 1000));
+  sendCommand('{"cmd":"set_readout_period","value":' + p + "}");
+});
+$("historyBtn").addEventListener("click", () => sendCommand("h"));
+
+if (!("serial" in navigator)) log("Web Serial unavailable. Use Chrome over https or http://localhost.");
+</script>
+</body>
+</html>

--- a/scripts/test_pyusb_discovery.py
+++ b/scripts/test_pyusb_discovery.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Minimal test: can the AirCube be found and read via pyusb (libusb)?
+
+This is the direct counterpart to test_serial_discovery.py. Instead of relying
+on a /dev/ttyACM* serial node (which Crostini often never creates for the
+ESP32-H2's native USB Serial/JTAG), it talks to the raw USB device through
+libusb. If this script finds the device and reads JSON lines while the serial
+script finds nothing, then switching aircube_app.py to pyusb is the fix.
+
+Run:  python3 test_pyusb_discovery.py
+Deps: pyusb   (pip install pyusb)   + a libusb backend
+        - Debian/Crostini: sudo apt install libusb-1.0-0
+        - You may need a udev rule so the device is readable without root:
+            SUBSYSTEM=="usb", ATTR{idVendor}=="303a", MODE="0666"
+          (/etc/udev/rules.d/99-aircube.rules, then `sudo udevadm trigger`)
+          or just run this script with sudo for a quick test.
+"""
+
+import os
+import sys
+import time
+
+try:
+    import usb.core
+    import usb.util
+except ImportError:
+    sys.exit("pyusb is not installed. Run: pip install pyusb")
+
+# ESP32-H2 USB Serial/JTAG ("USB JTAG/serial debug unit").
+ESPRESSIF_VID = 0x303A
+JTAG_SERIAL_PID = 0x1001
+READ_SECONDS = 12
+
+
+def main():
+    print("=== pyusb discovery (raw libusb, bypasses /dev/ttyACM) ===\n")
+
+    # 1. Enumerate everything so we can see what libusb sees at all.
+    all_devs = list(usb.core.find(find_all=True))
+    if not all_devs:
+        print("libusb found NO usb devices at all.")
+        print("On Crostini, make sure the AirCube is shared into Linux:")
+        print("  ChromeOS Settings > 'USB JTAG/serial debug unit' > toggle into Linux.")
+        return
+
+    print(f"libusb sees {len(all_devs)} USB device(s):")
+    for d in all_devs:
+        print(f"  VID:PID = 0x{d.idVendor:04X}:0x{d.idProduct:04X}")
+    print()
+
+    # 2. Find the AirCube specifically.
+    dev = usb.core.find(idVendor=ESPRESSIF_VID, idProduct=JTAG_SERIAL_PID)
+    if dev is None:
+        # Fall back to any Espressif device in case the PID differs.
+        dev = usb.core.find(idVendor=ESPRESSIF_VID)
+    if dev is None:
+        print("--> No Espressif (VID 0x303A) device found via libusb either.")
+        print("    The device is likely not shared into the Linux container yet.")
+        return
+
+    print(f"--> Found AirCube: 0x{dev.idVendor:04X}:0x{dev.idProduct:04X}")
+
+    try:
+        cfg = dev.get_active_configuration()
+    except usb.core.USBError:
+        dev.set_configuration()
+        cfg = dev.get_active_configuration()
+
+    # 3. Dump the real descriptor. The ESP32-H2 USB Serial/JTAG enumerates as a
+    #    VENDOR-SPECIFIC device (every interface class 0xFF), not standard CDC --
+    #    which is exactly why Crostini's cdc-acm driver never created /dev/ttyACM
+    #    and pyserial saw nothing. Layout:
+    #      interface 0: interrupt IN  -> notifications / control
+    #      interface 1: bulk OUT+IN   -> the serial console stream (our JSON)  <-- want
+    #      interface 2: bulk OUT+IN   -> JTAG                                  <-- skip
+    #    So we pick the FIRST interface that has both a bulk IN and bulk OUT.
+    print("\n    --- configuration descriptor ---")
+    data_intf = None       # interface object that owns the serial bulk IN
+    ep_in = None
+    comm_intf = 0          # interrupt/control interface = DTR/RTS target
+    for intf in cfg:
+        print(f"    interface {intf.bInterfaceNumber} alt {intf.bAlternateSetting} "
+              f"class 0x{intf.bInterfaceClass:02X} subclass 0x{intf.bInterfaceSubClass:02X}")
+        bulk_in = bulk_out = None
+        for ep in intf:
+            direction = "IN" if usb.util.endpoint_direction(ep.bEndpointAddress) == usb.util.ENDPOINT_IN else "OUT"
+            ep_type = {0: "control", 1: "iso", 2: "bulk", 3: "interrupt"}[usb.util.endpoint_type(ep.bmAttributes)]
+            print(f"        ep 0x{ep.bEndpointAddress:02X} {direction} {ep_type} maxpkt {ep.wMaxPacketSize}")
+            if usb.util.endpoint_type(ep.bmAttributes) == usb.util.ENDPOINT_TYPE_BULK:
+                if usb.util.endpoint_direction(ep.bEndpointAddress) == usb.util.ENDPOINT_IN:
+                    bulk_in = ep
+                else:
+                    bulk_out = ep
+        # First interface carrying both bulk IN and bulk OUT = the serial port.
+        if ep_in is None and bulk_in is not None and bulk_out is not None:
+            ep_in = bulk_in
+            data_intf = intf
+    print("    --------------------------------\n")
+
+    if ep_in is None:
+        print("--> No bulk IN endpoint found on any interface. Cannot read.")
+        return
+    print(f"    data: bulk IN 0x{ep_in.bEndpointAddress:02X} on interface {data_intf.bInterfaceNumber}")
+    print(f"    comm: control interface {comm_intf}")
+
+    # 4. Detach any kernel driver and claim the data interface so our IN tokens
+    #    actually pull bytes (an unclaimed interface can let the kernel race us).
+    for n in {data_intf.bInterfaceNumber, comm_intf}:
+        if n is None:
+            continue
+        try:
+            if dev.is_kernel_driver_active(n):
+                dev.detach_kernel_driver(n)
+                print(f"    detached kernel driver from interface {n}")
+        except (NotImplementedError, usb.core.USBError):
+            pass
+    for n in (data_intf.bInterfaceNumber, comm_intf):
+        try:
+            usb.util.claim_interface(dev, n)
+            print(f"    claimed interface {n}")
+        except usb.core.USBError as e:
+            print(f"    warning: could not claim interface {n} ({e})")
+
+    # 5. The ESP32-H2 docs say TX flushes after a newline and the device waits
+    #    ~50ms for the host to request data -- i.e. actively reading the IN
+    #    endpoint *should* be enough, no DTR needed. So by DEFAULT we do a clean
+    #    read-only test and dump RAW HEX of whatever arrives (not just parsed
+    #    JSON), to distinguish "no bytes at all" from "bytes that didn't parse".
+    #
+    #    The DTR/CDC handshake (which keeps timing out through Crostini) is only
+    #    attempted if you set TRY_DTR=1, so it can't wedge the endpoint by default.
+    if os.environ.get("TRY_DTR") == "1":
+        try:
+            coding = dev.ctrl_transfer(0xA1, 0x21, 0, comm_intf, 7, timeout=2000)
+            print(f"    GET_LINE_CODING -> {bytes(coding).hex()}")
+        except usb.core.USBError as e:
+            print(f"    GET_LINE_CODING failed ({e})")
+        for wValue, label in [(0x0003, "DTR|RTS"), (0x0001, "DTR")]:
+            try:
+                dev.ctrl_transfer(0x21, 0x22, wValue, comm_intf, None, timeout=3000)
+                print(f"    SET_CONTROL_LINE_STATE OK [{label}]")
+                break
+            except usb.core.USBError as e:
+                print(f"    SET_CONTROL_LINE_STATE failed [{label}]: {e}")
+
+    # Clear any stale halt/toggle on the IN endpoints before reading.
+    in_eps = [ep_in.bEndpointAddress]
+    if ep_in.bEndpointAddress != 0x83:
+        in_eps.append(0x83)  # also probe the JTAG IN endpoint, just in case
+    for addr in in_eps:
+        try:
+            dev.clear_halt(addr)
+        except usb.core.USBError:
+            pass
+
+    print(f"\n    Reading for {READ_SECONDS}s (move/breathe near the sensor)...")
+    print(f"    polling IN endpoints: {', '.join(f'0x{a:02X}' for a in in_eps)}\n")
+    buf = bytearray()
+    total_bytes = 0
+    deadline = time.monotonic() + READ_SECONDS
+    while time.monotonic() < deadline:
+        for addr in in_eps:
+            try:
+                chunk = dev.read(addr, 64, timeout=200)
+            except usb.core.USBError as e:
+                if e.errno == 110:  # timeout/NAK, keep polling
+                    continue
+                print(f"    read error on 0x{addr:02X}: {e}")
+                continue
+            if chunk:
+                raw = chunk.tobytes()
+                total_bytes += len(raw)
+                # Show raw hex so we see ANY traffic, even non-JSON.
+                print(f"    RX 0x{addr:02X} [{len(raw)}B]: {raw.hex()}")
+                buf.extend(raw)
+                while b"\n" in buf:
+                    line, _, buf = buf.partition(b"\n")
+                    text = line.decode(errors="ignore").strip()
+                    if text:
+                        print(f"        parsed: {text}")
+
+    print()
+    if total_bytes:
+        print(f"--> SUCCESS: read {total_bytes} bytes directly via pyusb.")
+        print("    Confirms pyusb is a viable replacement for the serial path.")
+    else:
+        print("--> No bytes on any IN endpoint. Re-run with TRY_DTR=1 to test whether")
+        print("    asserting DTR is required:  sudo TRY_DTR=1 .../python .../test_pyusb_discovery.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_serial_discovery.py
+++ b/scripts/test_serial_discovery.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Minimal test: can the AirCube be found via pyserial?
+
+This mirrors exactly what aircube_app.py does to discover the device:
+it calls serial.tools.list_ports.comports() and lists what it finds.
+
+On a Chromebook (Crostini), the ESP32-H2's native USB Serial/JTAG device
+often does NOT show up here, because no cdc-acm /dev/ttyACM* node is created
+in the Linux container. If this script prints "No serial ports found" (or
+lists ports but none from Espressif), that confirms the pyserial path is the
+problem.
+
+Run:  python3 test_serial_discovery.py
+Deps: pyserial   (already a dependency of aircube_app.py)
+"""
+
+from serial.tools import list_ports
+
+# ESP32-H2 USB Serial/JTAG = Espressif vendor ID. PID for the
+# "USB JTAG/serial debug unit" is 0x1001.
+ESPRESSIF_VID = 0x303A
+
+
+def main():
+    print("=== pyserial discovery (same call aircube_app.py uses) ===\n")
+    ports = list(list_ports.comports())
+
+    if not ports:
+        print("No serial ports found.")
+        print("\n--> pyserial cannot see ANY device. This is the failure")
+        print("    the AirCube app hits on the Chromebook. Try test_pyusb_discovery.py.")
+        return
+
+    found_esp = False
+    for p in ports:
+        vid = f"0x{p.vid:04X}" if p.vid is not None else "----"
+        pid = f"0x{p.pid:04X}" if p.pid is not None else "----"
+        print(f"  {p.device}")
+        print(f"      description : {p.description}")
+        print(f"      hwid        : {p.hwid}")
+        print(f"      VID:PID     : {vid}:{pid}")
+        if p.vid == ESPRESSIF_VID:
+            found_esp = True
+            print("      ^^^ This is an Espressif device (likely the AirCube).")
+        print()
+
+    if found_esp:
+        print("--> An Espressif serial port WAS found. pyserial should work here.")
+    else:
+        print("--> Ports exist, but NONE are Espressif (VID 0x303A).")
+        print("    The AirCube is not exposed as a serial port. Try test_pyusb_discovery.py.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/webserial_aircube_test.html
+++ b/scripts/webserial_aircube_test.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>AirCube Web Serial signal tester</title>
+<style>
+  body { font-family: system-ui, sans-serif; margin: 2rem; max-width: 820px; }
+  button { font-size: 0.95rem; padding: 0.45rem 0.9rem; cursor: pointer; margin: 0.15rem; }
+  #log { white-space: pre-wrap; background: #111; color: #0f0; padding: 1rem;
+         border-radius: 6px; height: 340px; overflow-y: auto; margin-top: 1rem;
+         font-family: ui-monospace, monospace; font-size: 0.82rem; }
+  .row { margin: 0.5rem 0; }
+  .vals { display: flex; gap: 1.2rem; margin-top: 1rem; flex-wrap: wrap; }
+  .vals div { background: #f2f2f2; padding: 0.5rem 0.9rem; border-radius: 6px; }
+  .vals b { display: block; font-size: 1.3rem; }
+  #count { font-weight: bold; }
+</style>
+</head>
+<body>
+<h1>AirCube Web Serial signal tester</h1>
+<p>
+  Goal: find the DTR/RTS combination that makes the ESP32-H2 USB Serial/JTAG
+  stream. Open the port (no signals forced), then try buttons one at a time and
+  watch the byte counter. Setting RTS may reset the chip into download mode --
+  if the port disconnects, that is what happened.
+</p>
+
+<div class="row">
+  <button id="connect">1. Connect (open, no signals)</button>
+  <span id="count">bytes: 0</span>
+</div>
+<div class="row">
+  <button data-dtr="1" data-rts="0">DTR=1 RTS=0</button>
+  <button data-dtr="0" data-rts="0">DTR=0 RTS=0</button>
+  <button data-dtr="1" data-rts="1">DTR=1 RTS=1</button>
+  <button data-dtr="0" data-rts="1">DTR=0 RTS=1</button>
+  <button id="pulseDtr">Pulse DTR (0-&gt;1)</button>
+</div>
+
+<div class="vals">
+  <div>Temp (F)<b id="tempF">--</b></div>
+  <div>Humidity<b id="hum">--</b></div>
+  <div>eCO2<b id="eco2">--</b></div>
+  <div>TVOC<b id="tvoc">--</b></div>
+  <div>AQI<b id="aqi">--</b></div>
+</div>
+<div id="log"></div>
+
+<script>
+const VID = 0x303A;
+const logEl = document.getElementById("log");
+const countEl = document.getElementById("count");
+function log(m) { logEl.textContent += m + "\n"; logEl.scrollTop = logEl.scrollHeight; }
+
+let port = null, reading = false, rxBuf = "", totalBytes = 0;
+
+navigator.serial?.addEventListener("disconnect", (e) => {
+  log("*** PORT DISCONNECTED (device reset / re-enumerated). Reconnect to continue. ***");
+  reading = false;
+});
+
+async function setSig(dtr, rts) {
+  if (!port) { log("not connected"); return; }
+  try {
+    await port.setSignals({ dataTerminalReady: !!dtr, requestToSend: !!rts });
+    log(`setSignals DTR=${dtr} RTS=${rts} -> ok`);
+  } catch (e) { log("setSignals failed: " + e); }
+}
+
+async function connect() {
+  if (!("serial" in navigator)) { log("Web Serial unavailable (use Chrome over localhost/https)."); return; }
+  try { port = await navigator.serial.requestPort({ filters: [{ usbVendorId: VID }] }); }
+  catch (e) { log("no port selected: " + e); return; }
+  const i = port.getInfo();
+  log("selected 0x" + (i.usbVendorId||0).toString(16) + ":0x" + (i.usbProductId||0).toString(16));
+  try { await port.open({ baudRate: 115200 }); log("opened 115200"); }
+  catch (e) { log("open failed: " + e); return; }
+  reading = true; totalBytes = 0;
+  // DTR=0 RTS=1 is the combo that makes this ESP32-H2 USB Serial/JTAG stream.
+  // DTR=1 resets/halts the chip, so we explicitly hold DTR low and RTS high.
+  await setSig(0, 1);
+  log("\nlistening (DTR=0 RTS=1)...\n");
+  readLoop();
+}
+
+async function readLoop() {
+  const dec = new TextDecoder();
+  let reader;
+  try { reader = port.readable.getReader(); }
+  catch (e) { log("getReader failed: " + e); return; }
+  try {
+    while (reading) {
+      const { value, done } = await reader.read();
+      if (done) { log("reader done"); break; }
+      if (value && value.length) {
+        totalBytes += value.length;
+        countEl.textContent = "bytes: " + totalBytes;
+        rxBuf += dec.decode(value);
+        let nl;
+        while ((nl = rxBuf.indexOf("\n")) >= 0) {
+          const line = rxBuf.slice(0, nl).trim();
+          rxBuf = rxBuf.slice(nl + 1);
+          if (line) handleLine(line);
+        }
+      }
+    }
+  } catch (e) { log("read error: " + e); }
+  finally { try { reader.releaseLock(); } catch (e) {} }
+}
+
+function handleLine(line) {
+  log("RX: " + line);
+  try {
+    const j = JSON.parse(line);
+    if (j.ens210) {
+      document.getElementById("tempF").textContent = j.ens210.temperature_f?.toFixed(1) ?? "--";
+      document.getElementById("hum").textContent   = j.ens210.humidity?.toFixed(0) ?? "--";
+    }
+    if (j.ens16x) {
+      document.getElementById("eco2").textContent = j.ens16x.eco2 ?? "--";
+      document.getElementById("tvoc").textContent = j.ens16x.etvoc ?? "--";
+      document.getElementById("aqi").textContent  = j.ens16x.aqi ?? "--";
+    }
+  } catch (e) {}
+}
+
+document.getElementById("connect").addEventListener("click", connect);
+document.querySelectorAll("button[data-dtr]").forEach(b =>
+  b.addEventListener("click", () => setSig(+b.dataset.dtr, +b.dataset.rts)));
+document.getElementById("pulseDtr").addEventListener("click", async () => {
+  await setSig(0, 0); await new Promise(r => setTimeout(r, 100)); await setSig(1, 0);
+});
+if (!("serial" in navigator)) log("Web Serial unavailable (use Chrome over localhost/https).");
+</script>
+</body>
+</html>

--- a/scripts/webusb_aircube_test.html
+++ b/scripts/webusb_aircube_test.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>AirCube WebUSB test</title>
+<style>
+  body { font-family: system-ui, sans-serif; margin: 2rem; max-width: 760px; }
+  button { font-size: 1rem; padding: 0.5rem 1rem; cursor: pointer; }
+  #log { white-space: pre-wrap; background: #111; color: #0f0; padding: 1rem;
+         border-radius: 6px; height: 360px; overflow-y: auto; margin-top: 1rem;
+         font-family: ui-monospace, monospace; font-size: 0.85rem; }
+  .vals { display: flex; gap: 1.5rem; margin-top: 1rem; flex-wrap: wrap; }
+  .vals div { background: #f2f2f2; padding: 0.6rem 1rem; border-radius: 6px; }
+  .vals b { display: block; font-size: 1.4rem; }
+</style>
+</head>
+<body>
+<h1>AirCube WebUSB test</h1>
+<p>
+  Counterpart to <code>test_pyusb_discovery.py</code>, but via the browser's
+  WebUSB. This bypasses Crostini's USB passthrough (which drops the DTR
+  control-OUT) and talks to the ESP32-H2 USB Serial/JTAG directly. If this
+  reads JSON, a WebUSB-based reader is the way to run AirCube on a Chromebook.
+</p>
+<button id="connect">Connect to AirCube</button>
+<div class="vals">
+  <div>Temp (F)<b id="tempF">--</b></div>
+  <div>Humidity<b id="hum">--</b></div>
+  <div>eCO2<b id="eco2">--</b></div>
+  <div>TVOC<b id="tvoc">--</b></div>
+  <div>AQI<b id="aqi">--</b></div>
+</div>
+<div id="log"></div>
+
+<script>
+// ESP32-H2 USB Serial/JTAG. Same IDs the pyusb script matched.
+const VID = 0x303A, PID = 0x1001;
+
+// Layout confirmed by the pyusb descriptor dump:
+//   interface 0: interrupt IN 0x82      -> CDC comm / control (DTR target)
+//   interface 1: bulk OUT 0x01, IN 0x81 -> serial console stream (our JSON)
+//   interface 2: bulk OUT/IN            -> JTAG (ignored)
+const COMM_INTERFACE = 0;
+const DATA_INTERFACE = 1;
+const EP_IN = 1;            // 0x81 -> endpoint number 1, IN direction
+
+const logEl = document.getElementById('log');
+function log(msg) {
+  logEl.textContent += msg + "\n";
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+let device = null;
+let reading = false;
+let rxBuf = "";
+
+async function connect() {
+  try {
+    device = await navigator.usb.requestDevice({ filters: [{ vendorId: VID, productId: PID }] });
+  } catch (e) {
+    log("No device selected: " + e);
+    return;
+  }
+  log("Selected: 0x" + device.vendorId.toString(16) + ":0x" + device.productId.toString(16));
+
+  await device.open();
+  if (device.configuration === null) await device.selectConfiguration(1);
+  log("Opened, configuration " + device.configuration.configurationValue);
+
+  // Claim both the comm interface (for the DTR control request) and the data
+  // interface (for the bulk IN stream). 0xFF interfaces are claimable in WebUSB.
+  for (const n of [COMM_INTERFACE, DATA_INTERFACE]) {
+    try { await device.claimInterface(n); log("claimed interface " + n); }
+    catch (e) { log("claim interface " + n + " failed: " + e); }
+  }
+
+  // Assert DTR (and RTS) -- SET_CONTROL_LINE_STATE. This is the request that
+  // times out through Crostini libusb; WebUSB should deliver it directly.
+  try {
+    const r = await device.controlTransferOut({
+      requestType: "class",
+      recipient: "interface",
+      request: 0x22,          // SET_CONTROL_LINE_STATE
+      value: 0x0003,          // bit0 DTR, bit1 RTS
+      index: COMM_INTERFACE
+    });
+    log("SET_CONTROL_LINE_STATE -> " + r.status);
+  } catch (e) {
+    log("SET_CONTROL_LINE_STATE failed: " + e + " (reading anyway)");
+  }
+
+  reading = true;
+  log("\nReading... (move/breathe near the sensor)\n");
+  readLoop();
+}
+
+async function readLoop() {
+  while (reading && device) {
+    let result;
+    try {
+      result = await device.transferIn(EP_IN, 64);
+    } catch (e) {
+      log("read error: " + e);
+      break;
+    }
+    if (result.status !== "ok") { log("transfer status: " + result.status); continue; }
+    if (result.data && result.data.byteLength) {
+      const text = new TextDecoder().decode(result.data);
+      rxBuf += text;
+      let nl;
+      while ((nl = rxBuf.indexOf("\n")) >= 0) {
+        const line = rxBuf.slice(0, nl).trim();
+        rxBuf = rxBuf.slice(nl + 1);
+        if (line) handleLine(line);
+      }
+    }
+  }
+}
+
+function handleLine(line) {
+  log("RX: " + line);
+  try {
+    const j = JSON.parse(line);
+    if (j.ens210) {
+      document.getElementById("tempF").textContent = j.ens210.temperature_f?.toFixed(1) ?? "--";
+      document.getElementById("hum").textContent   = j.ens210.humidity?.toFixed(0) ?? "--";
+    }
+    if (j.ens16x) {
+      document.getElementById("eco2").textContent = j.ens16x.eco2 ?? "--";
+      document.getElementById("tvoc").textContent = j.ens16x.etvoc ?? "--";
+      document.getElementById("aqi").textContent  = j.ens16x.aqi ?? "--";
+    }
+  } catch (e) { /* non-JSON console line; already logged raw */ }
+}
+
+document.getElementById("connect").addEventListener("click", connect);
+if (!("usb" in navigator)) {
+  log("WebUSB not available. Use Chrome, and serve this page over https or http://localhost (a secure context).");
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `scripts/aircube_webapp.html`, a browser-based replacement for the `aircube_app.py` desktop app that works on Chromebooks (and any Chrome/Edge browser).

The PyQt6 desktop app cannot run on a Chromebook:
- **pyserial sees nothing** -- the Crostini (termina) VM kernel has no `cdc-acm` module, so no `/dev/ttyACM*` is ever created.
- **pyusb can open the device but not read** -- the ESP32-H2 USB Serial/JTAG gates TX until the host marks the port "connected", and the required `SET_CONTROL_LINE_STATE` (class interface-OUT) control transfer **times out** through ChromeOS/Crostini's USB passthrough.

The web app reads over the **Web Serial API** instead (through the ChromeOS host's `cdc-acm` driver), using the **`DTR=0 RTS=1`** handshake the ESP32-H2 USB Serial/JTAG requires. Note: `DTR=1` resets/halts the chip, which was the root cause of an initially silent stream.

## What's included

- `aircube_webapp.html` -- full app: live value cards (with AQI color bands), C/F toggle, three scrolling charts (canvas, no external libs), CSV logging (session download + File System Access streaming), field-definition tooltips, and device controls (`get_config`, `set_intensity`, `set_readout_period`, history dump). Apache 2.0 header.
- `WEBAPP_README.md` -- usage, the full Chromebook investigation, serial protocol reference, and troubleshooting.
- Diagnostic artifacts referenced by the README: `webserial_aircube_test.html`, `webusb_aircube_test.html`, `test_serial_discovery.py`, `test_pyusb_discovery.py`.

## Testing

Verified live streaming, charts, C/F toggle, CSV download, and `get_config`/`set_intensity` round-trips against an AirCube on a Chromebook over `http://localhost`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)